### PR TITLE
feat: implement log levels and fmt line info log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,6 +166,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,6 +185,35 @@ name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "env_filter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
+]
 
 [[package]]
 name = "errno"
@@ -209,6 +260,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "ignore"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,6 +286,12 @@ name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -253,12 +316,16 @@ name = "mdsf"
 version = "0.0.3"
 dependencies = [
  "clap",
+ "console",
+ "env_logger",
  "ignore",
+ "log",
  "once_cell",
  "regex",
  "schemars",
  "serde",
  "serde_json",
+ "simplelog",
  "tempfile",
  "test-with",
  "which 6.0.1",
@@ -271,10 +338,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro-error"
@@ -442,6 +530,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "simplelog"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16257adbfaef1ee58b1363bdc0664c9b8e1e30aed86049635fb5f147d065a9c0"
+dependencies = [
+ "log",
+ "termcolor",
+ "time",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,6 +581,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "test-with"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,10 +604,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+dependencies = [
+ "deranged",
+ "itoa",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,15 +166,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
-name = "deranged"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
-dependencies = [
- "powerfmt",
-]
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,7 +316,6 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "simplelog",
  "tempfile",
  "test-with",
  "which 6.0.1",
@@ -338,31 +328,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
-name = "num-conv"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num_threads"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro-error"
@@ -530,17 +499,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simplelog"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16257adbfaef1ee58b1363bdc0664c9b8e1e30aed86049635fb5f147d065a9c0"
-dependencies = [
- "log",
- "termcolor",
- "time",
-]
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -581,15 +539,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "test-with"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,39 +550,6 @@ dependencies = [
  "regex",
  "syn 2.0.58",
  "which 5.0.0",
-]
-
-[[package]]
-name = "time"
-version = "0.3.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
-dependencies = [
- "deranged",
- "itoa",
- "libc",
- "num-conv",
- "num_threads",
- "powerfmt",
- "serde",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
-
-[[package]]
-name = "time-macros"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
-dependencies = [
- "num-conv",
- "time-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ regex = "1.10.4"
 schemars = "0.8.16"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.115"
-simplelog = "0.12.2"
 tempfile = "3.10.1"
 which = "6.0.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,16 @@ categories = ["development-tools"]
 
 [dependencies]
 clap = { version = "4.5.4", features = ["derive"] }
+console = "0.15.8"
+env_logger = "0.11.3"
 ignore = "0.4.22"
+log = "0.4.21"
 once_cell = "1.19.0"
 regex = "1.10.4"
 schemars = "0.8.16"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.115"
+simplelog = "0.12.2"
 tempfile = "3.10.1"
 which = "6.0.1"
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -32,7 +32,7 @@ pub struct FormatCommandArguments {
     pub log_level: LogLevel,
 }
 
-#[derive(clap::ValueEnum, Clone, Copy, PartialEq, Default, Debug)]
+#[derive(clap::ValueEnum, Clone, Copy, PartialEq, Eq, Default, Debug)]
 pub enum LogLevel {
     #[default]
     Trace,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,4 +27,18 @@ pub struct FormatCommandArguments {
     /// Log stdout and stderr of formatters
     #[arg(long, default_value_t = false)]
     pub debug: bool,
+
+    #[arg(long, default_value_t, value_enum)]
+    pub log_level: LogLevel,
+}
+
+#[derive(clap::ValueEnum, Clone, Copy, PartialEq, Default, Debug)]
+pub enum LogLevel {
+    #[default]
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+    Off,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,11 +14,11 @@ use crate::{
         typescript::TypeScript, vue::Vue, xml::Xml, yaml::Yaml, zig::Zig, Lang,
     },
     runners::JavaScriptRuntime,
-    terminal::print_config_info,
+    terminal::print_config_not_found,
 };
 
-#[derive(Debug, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq,))]
 pub struct MdsfConfig {
     #[schemars(skip)]
     #[serde(rename = "$schema", default = "default_schema_location")]
@@ -263,7 +263,6 @@ impl MdsfConfig {
         match std::fs::read_to_string(&path) {
             Ok(raw_config) => {
                 if let Ok(config) = serde_json::from_str::<Self>(&raw_config) {
-                    print_config_info(Some(&path));
                     Ok(config)
                 } else {
                     Err(MdsfError::ConfigParse(path))
@@ -271,7 +270,7 @@ impl MdsfConfig {
             }
             Err(error) => match error.kind() {
                 std::io::ErrorKind::NotFound => {
-                    print_config_info(None);
+                    print_config_not_found();
                     Ok(Self::default())
                 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -262,20 +262,16 @@ impl MdsfConfig {
 
         match std::fs::read_to_string(&path) {
             Ok(raw_config) => {
-                if let Ok(config) = serde_json::from_str::<Self>(&raw_config) {
-                    Ok(config)
-                } else {
-                    Err(MdsfError::ConfigParse(path))
-                }
+                serde_json::from_str::<Self>(&raw_config).map_err(|_| MdsfError::ConfigParse(path))
             }
-            Err(error) => match error.kind() {
-                std::io::ErrorKind::NotFound => {
+            Err(error) => {
+                if error.kind() == std::io::ErrorKind::NotFound {
                     print_config_not_found();
                     Ok(Self::default())
+                } else {
+                    Err(MdsfError::from(error))
                 }
-
-                _ => Err(MdsfError::from(error)),
-            },
+            }
         }
     }
 }

--- a/src/formatters/alejandra.rs
+++ b/src/formatters/alejandra.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_alejandra(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("alejandra");
-
     let mut cmd = std::process::Command::new("alejandra");
 
     cmd.arg("--quiet").arg(snippet_path);
@@ -22,7 +19,7 @@ mod test_alejandra {
     #[test_with::executable(alejandra)]
     #[test]
     fn it_should_format_nix() {
-        let input = r#"{ 
+        let input = r#"{
             lib, buildPythonPackage, fetchFromGitHub, redis }:
 
 buildPythonPackage rec {

--- a/src/formatters/autopep8.rs
+++ b/src/formatters/autopep8.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_autopep8(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("autopep8");
-
     let mut cmd = std::process::Command::new("autopep8");
 
     cmd.arg("--in-place").arg(snippet_path);

--- a/src/formatters/beautysh.rs
+++ b/src/formatters/beautysh.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_beautysh(
     file_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("beautysh");
-
     let mut cmd = std::process::Command::new("beautysh");
 
     cmd.arg(file_path);

--- a/src/formatters/biome.rs
+++ b/src/formatters/biome.rs
@@ -1,12 +1,10 @@
 use super::execute_command;
-use crate::{runners::setup_npm_script, terminal::print_formatter_info};
+use crate::runners::setup_npm_script;
 
 #[inline]
 pub fn format_using_biome(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("biome");
-
     // NOTE: the biome docs recommend running biome using npx, and not directly
     let mut cmd = setup_npm_script("@biomejs/biome");
 

--- a/src/formatters/black.rs
+++ b/src/formatters/black.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_black(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("black");
-
     let mut cmd = std::process::Command::new("black");
 
     cmd.arg("--quiet").arg(snippet_path);

--- a/src/formatters/blade_formatter.rs
+++ b/src/formatters/blade_formatter.rs
@@ -1,5 +1,5 @@
 use super::execute_command;
-use crate::{runners::setup_npm_script, terminal::print_formatter_info};
+use crate::runners::setup_npm_script;
 
 #[inline]
 fn set_blade_formatter_args(cmd: &mut std::process::Command, snippet_path: &std::path::Path) {
@@ -20,8 +20,6 @@ fn invote_blade_formatter(
 pub fn format_using_blade_formatter(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("blade-formatter");
-
     invote_blade_formatter(setup_npm_script("blade-formatter"), snippet_path)
 }
 

--- a/src/formatters/blue.rs
+++ b/src/formatters/blue.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_blue(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("blue");
-
     let mut cmd = std::process::Command::new("blue");
 
     cmd.arg("--quiet").arg(snippet_path);

--- a/src/formatters/buf.rs
+++ b/src/formatters/buf.rs
@@ -1,10 +1,7 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_buf(snippet_path: &std::path::Path) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("buf");
-
     let mut cmd = std::process::Command::new("buf");
 
     cmd.arg("format").arg("--write").arg(snippet_path);

--- a/src/formatters/cabal_format.rs
+++ b/src/formatters/cabal_format.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_cabal_format(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("cabal_format");
-
     let mut cmd = std::process::Command::new("cabal");
 
     cmd.arg("format").arg(snippet_path);
@@ -23,12 +20,12 @@ mod test_cabal_format {
     #[test]
     fn it_should_format_cabal() {
         let input = "cabal-version: 2.4
-name: mdsf 
+name: mdsf
 version: 0
 
-executable msdf 
+executable msdf
     default-language: Haskell2010
-    hs-source-dirs: src 
+    hs-source-dirs: src
     main-is: Mdsf.hs
     build-depends: base >=4.11 && <4.13, pretty >=1.1.3.6 && <1.2, bytestring, Cabal ^>=2.5, containers ^>=0.5.11.0 || ^>=0.6.0.1
     other-extensions:

--- a/src/formatters/clang_format.rs
+++ b/src/formatters/clang_format.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_clang_format(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("clang-format");
-
     let mut cmd = std::process::Command::new("clang-format");
 
     cmd.arg("-i").arg(snippet_path);

--- a/src/formatters/cljstyle.rs
+++ b/src/formatters/cljstyle.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_cljstyle(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("cljstyle");
-
     let mut cmd = std::process::Command::new("cljstyle");
 
     cmd.arg("fix").arg(snippet_path);

--- a/src/formatters/crystal_format.rs
+++ b/src/formatters/crystal_format.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_crystal_format(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("crystal");
-
     let mut cmd = std::process::Command::new("crystal");
 
     cmd.arg("tool").arg("format").arg(snippet_path);

--- a/src/formatters/csharpier.rs
+++ b/src/formatters/csharpier.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_csharpier(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("csharpier");
-
     let mut cmd = std::process::Command::new("dotnet");
 
     cmd.arg("csharpier").arg(snippet_path);

--- a/src/formatters/dart_format.rs
+++ b/src/formatters/dart_format.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_dart_format(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("dart_format");
-
     let mut cmd = std::process::Command::new("dart");
 
     cmd.arg("format").arg(snippet_path);

--- a/src/formatters/deno_fmt.rs
+++ b/src/formatters/deno_fmt.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_deno_fmt(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("deno_fmt");
-
     let mut cmd = std::process::Command::new("deno");
 
     cmd.arg("fmt").arg("--quiet").arg(snippet_path);

--- a/src/formatters/efmt.rs
+++ b/src/formatters/efmt.rs
@@ -1,10 +1,7 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_efmt(file_path: &std::path::Path) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("efmt");
-
     let mut cmd = std::process::Command::new("efmt");
 
     cmd.arg("-w").arg(file_path);

--- a/src/formatters/elm_format.rs
+++ b/src/formatters/elm_format.rs
@@ -1,5 +1,5 @@
 use super::execute_command;
-use crate::{runners::setup_npm_script, terminal::print_formatter_info};
+use crate::runners::setup_npm_script;
 
 #[inline]
 fn set_elm_format_args(cmd: &mut std::process::Command, snippet_path: &std::path::Path) {
@@ -20,8 +20,6 @@ fn invoke_elm_format(
 pub fn format_using_elm_format(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("elm_format");
-
     invoke_elm_format(setup_npm_script("elm-format"), snippet_path)
 }
 

--- a/src/formatters/erlfmt.rs
+++ b/src/formatters/erlfmt.rs
@@ -1,10 +1,7 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_erlfmt(file_path: &std::path::Path) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("erlfmt");
-
     let mut cmd = std::process::Command::new("erlfmt");
 
     cmd.arg("-w")

--- a/src/formatters/fantomas.rs
+++ b/src/formatters/fantomas.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_fantomas(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("fantomas");
-
     let mut cmd = std::process::Command::new("fantomas");
 
     cmd.arg(snippet_path);

--- a/src/formatters/fourmolu.rs
+++ b/src/formatters/fourmolu.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_fourmolu(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("fourmolu");
-
     let mut cmd = std::process::Command::new("fourmolu");
 
     cmd.arg("-i").arg(snippet_path);

--- a/src/formatters/gleam_format.rs
+++ b/src/formatters/gleam_format.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_gleam_format(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("gleam_format");
-
     let mut cmd = std::process::Command::new("gleam");
 
     cmd.arg("format").arg(snippet_path);

--- a/src/formatters/gofmt.rs
+++ b/src/formatters/gofmt.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_gofmt(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("gofmt");
-
     let mut cmd = std::process::Command::new("gofmt");
 
     cmd.arg("-w").arg(snippet_path);

--- a/src/formatters/gofumpt.rs
+++ b/src/formatters/gofumpt.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_gofumpt(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("gofumpt");
-
     let mut cmd = std::process::Command::new("gofumpt");
 
     cmd.arg("-w").arg(snippet_path);

--- a/src/formatters/goimports.rs
+++ b/src/formatters/goimports.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_goimports(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("goimports");
-
     let mut cmd = std::process::Command::new("goimports");
 
     cmd.arg("-w").arg(snippet_path);

--- a/src/formatters/google_java_format.rs
+++ b/src/formatters/google_java_format.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_google_java_format(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("google-java-format");
-
     let mut cmd = std::process::Command::new("google-java-format");
 
     cmd.arg("-i").arg(snippet_path);

--- a/src/formatters/hindent.rs
+++ b/src/formatters/hindent.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_hindent(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("hindent");
-
     let mut cmd = std::process::Command::new("hindent");
 
     cmd.arg(snippet_path);

--- a/src/formatters/isort.rs
+++ b/src/formatters/isort.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_isort(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("isort");
-
     let mut cmd = std::process::Command::new("isort");
 
     cmd.arg("--quiet").arg(snippet_path);

--- a/src/formatters/juliaformatter_jl.rs
+++ b/src/formatters/juliaformatter_jl.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_juliaformatter_jl(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("juliaformatter.jl");
-
     let mut cmd = std::process::Command::new("julia");
 
     cmd.arg("-E").arg(format!(
@@ -26,8 +23,8 @@ mod test_juliaformatter_jl {
     #[test]
     fn it_should_format_julia() {
         let input = "function add( a:: Int32,  b::Int32 )
-            c = a+ b  
-            return c 
+            c = a+ b
+            return c
             end ";
 
         let expected_output = "function add(a::Int32, b::Int32)

--- a/src/formatters/just_fmt.rs
+++ b/src/formatters/just_fmt.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_just_fmt(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("just_fmt");
-
     let mut cmd = std::process::Command::new("just");
 
     cmd.arg("--fmt")

--- a/src/formatters/ktfmt.rs
+++ b/src/formatters/ktfmt.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_ktfmt(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("ktfmt");
-
     let mut cmd = std::process::Command::new("ktfmt");
 
     cmd.arg("--format")

--- a/src/formatters/ktlint.rs
+++ b/src/formatters/ktlint.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_ktlint(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("ktlint");
-
     let mut cmd = std::process::Command::new("ktlint");
 
     cmd.arg("--format")

--- a/src/formatters/luaformatter.rs
+++ b/src/formatters/luaformatter.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_luaformatter(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("luaformatter");
-
     let mut cmd = std::process::Command::new("lua-format");
 
     cmd.arg("-i").arg(snippet_path);

--- a/src/formatters/mix_format.rs
+++ b/src/formatters/mix_format.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_mix_format(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("mix_format");
-
     let mut cmd = std::process::Command::new("mix");
 
     cmd.arg("format").arg(snippet_path);

--- a/src/formatters/mod.rs
+++ b/src/formatters/mod.rs
@@ -153,7 +153,7 @@ pub fn execute_command(
 }
 
 #[inline]
-pub fn format_snippet(config: &MdsfConfig, info: LineInfo, code: &str) -> String {
+pub fn format_snippet(config: &MdsfConfig, info: &LineInfo, code: &str) -> String {
     if let Ok(snippet) = setup_snippet(code, info.language.to_file_ext()) {
         let snippet_path = snippet.path();
 
@@ -223,7 +223,10 @@ pub fn format_snippet(config: &MdsfConfig, info: LineInfo, code: &str) -> String
 #[derive(Debug, serde::Serialize, serde::Deserialize, JsonSchema)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 #[serde(untagged)]
-pub enum MdsfFormatter<T> {
+pub enum MdsfFormatter<T>
+where
+    T: core::fmt::Display,
+{
     Single(T),
     Multiple(Vec<MdsfFormatter<T>>),
 }

--- a/src/formatters/mod.rs
+++ b/src/formatters/mod.rs
@@ -4,7 +4,9 @@ use schemars::JsonSchema;
 use tempfile::NamedTempFile;
 use which::which;
 
-use crate::{config::MdsfConfig, languages::Language, terminal::print_binary_not_in_path, DEBUG};
+use crate::{
+    config::MdsfConfig, languages::Language, terminal::print_binary_not_in_path, LineInfo, DEBUG,
+};
 
 pub mod alejandra;
 pub mod autopep8;
@@ -151,61 +153,61 @@ pub fn execute_command(
 }
 
 #[inline]
-pub fn format_snippet(config: &MdsfConfig, language: &Language, code: &str) -> String {
-    if let Ok(snippet) = setup_snippet(code, language.to_file_ext()) {
+pub fn format_snippet(config: &MdsfConfig, info: LineInfo, code: &str) -> String {
+    if let Ok(snippet) = setup_snippet(code, info.language.to_file_ext()) {
         let snippet_path = snippet.path();
 
-        if let Ok(Some(formatted_code)) = match language {
-            Language::Blade => config.blade.format(snippet_path),
-            Language::C => config.c.format(snippet_path),
-            Language::Cabal => config.cabal.format(snippet_path),
-            Language::Clojure => config.clojure.format(snippet_path),
-            Language::CSharp => config.csharp.format(snippet_path),
-            Language::Cpp => config.cpp.format(snippet_path),
-            Language::Crystal => config.crystal.format(snippet_path),
-            Language::Css(_flavor) => config.css.format(snippet_path),
-            Language::Dart => config.dart.format(snippet_path),
-            Language::Elixir => config.elixir.format(snippet_path),
-            Language::Elm => config.elm.format(snippet_path),
-            Language::Erlang => config.erlang.format(snippet_path),
-            Language::FSharp => config.fsharp.format(snippet_path),
-            Language::Gleam => config.gleam.format(snippet_path),
-            Language::Go => config.go.format(snippet_path),
-            Language::GraphQL => config.graphql.format(snippet_path),
-            Language::Groovy => config.groovy.format(snippet_path),
-            Language::Haskell => config.haskell.format(snippet_path),
-            Language::Hcl => config.hcl.format(snippet_path),
-            Language::Html => config.html.format(snippet_path),
-            Language::Java => config.java.format(snippet_path),
-            Language::JavaScript(_flavor) => config.javascript.format(snippet_path),
-            Language::Json(_flavor) => config.json.format(snippet_path),
-            Language::Julia => config.julia.format(snippet_path),
-            Language::Just => config.just.format(snippet_path),
-            Language::Kotlin => config.kotlin.format(snippet_path),
-            Language::Lua => config.lua.format(snippet_path),
-            Language::Markdown => config.markdown.format(snippet_path),
-            Language::Nix => config.nix.format(snippet_path),
-            Language::Nim => config.nim.format(snippet_path),
-            Language::OCaml => config.ocaml.format(snippet_path),
-            Language::ObjectiveC => config.objective_c.format(snippet_path),
-            Language::Perl => config.perl.format(snippet_path),
-            Language::Protobuf => config.protobuf.format(snippet_path),
-            Language::Python => config.python.format(snippet_path),
-            Language::PureScript => config.purescript.format(snippet_path),
-            Language::ReScript => config.rescript.format(snippet_path),
-            Language::Roc => config.roc.format(snippet_path),
-            Language::Ruby => config.ruby.format(snippet_path),
-            Language::Rust => config.rust.format(snippet_path),
-            Language::Scala => config.scala.format(snippet_path),
-            Language::Shell(_flavor) => config.shell.format(snippet_path),
-            Language::Sql => config.sql.format(snippet_path),
-            Language::Swift => config.swift.format(snippet_path),
-            Language::Toml => config.toml.format(snippet_path),
-            Language::TypeScript(_flavor) => config.typescript.format(snippet_path),
-            Language::Vue => config.vue.format(snippet_path),
-            Language::Xml => config.xml.format(snippet_path),
-            Language::Yaml => config.yaml.format(snippet_path),
-            Language::Zig => config.zig.format(snippet_path),
+        if let Ok(Some(formatted_code)) = match info.language {
+            Language::Blade => config.blade.format(snippet_path, info),
+            Language::C => config.c.format(snippet_path, info),
+            Language::Cabal => config.cabal.format(snippet_path, info),
+            Language::Clojure => config.clojure.format(snippet_path, info),
+            Language::CSharp => config.csharp.format(snippet_path, info),
+            Language::Cpp => config.cpp.format(snippet_path, info),
+            Language::Crystal => config.crystal.format(snippet_path, info),
+            Language::Css(_flavor) => config.css.format(snippet_path, info),
+            Language::Dart => config.dart.format(snippet_path, info),
+            Language::Elixir => config.elixir.format(snippet_path, info),
+            Language::Elm => config.elm.format(snippet_path, info),
+            Language::Erlang => config.erlang.format(snippet_path, info),
+            Language::FSharp => config.fsharp.format(snippet_path, info),
+            Language::Gleam => config.gleam.format(snippet_path, info),
+            Language::Go => config.go.format(snippet_path, info),
+            Language::GraphQL => config.graphql.format(snippet_path, info),
+            Language::Groovy => config.groovy.format(snippet_path, info),
+            Language::Haskell => config.haskell.format(snippet_path, info),
+            Language::Hcl => config.hcl.format(snippet_path, info),
+            Language::Html => config.html.format(snippet_path, info),
+            Language::Java => config.java.format(snippet_path, info),
+            Language::JavaScript(_flavor) => config.javascript.format(snippet_path, info),
+            Language::Json(_flavor) => config.json.format(snippet_path, info),
+            Language::Julia => config.julia.format(snippet_path, info),
+            Language::Just => config.just.format(snippet_path, info),
+            Language::Kotlin => config.kotlin.format(snippet_path, info),
+            Language::Lua => config.lua.format(snippet_path, info),
+            Language::Markdown => config.markdown.format(snippet_path, info),
+            Language::Nix => config.nix.format(snippet_path, info),
+            Language::Nim => config.nim.format(snippet_path, info),
+            Language::OCaml => config.ocaml.format(snippet_path, info),
+            Language::ObjectiveC => config.objective_c.format(snippet_path, info),
+            Language::Perl => config.perl.format(snippet_path, info),
+            Language::Protobuf => config.protobuf.format(snippet_path, info),
+            Language::Python => config.python.format(snippet_path, info),
+            Language::PureScript => config.purescript.format(snippet_path, info),
+            Language::ReScript => config.rescript.format(snippet_path, info),
+            Language::Roc => config.roc.format(snippet_path, info),
+            Language::Ruby => config.ruby.format(snippet_path, info),
+            Language::Rust => config.rust.format(snippet_path, info),
+            Language::Scala => config.scala.format(snippet_path, info),
+            Language::Shell(_flavor) => config.shell.format(snippet_path, info),
+            Language::Sql => config.sql.format(snippet_path, info),
+            Language::Swift => config.swift.format(snippet_path, info),
+            Language::Toml => config.toml.format(snippet_path, info),
+            Language::TypeScript(_flavor) => config.typescript.format(snippet_path, info),
+            Language::Vue => config.vue.format(snippet_path, info),
+            Language::Xml => config.xml.format(snippet_path, info),
+            Language::Yaml => config.yaml.format(snippet_path, info),
+            Language::Zig => config.zig.format(snippet_path, info),
         } {
             let mut f = formatted_code.trim().to_owned();
 

--- a/src/formatters/nimpretty.rs
+++ b/src/formatters/nimpretty.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_nimpretty(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("nimpretty");
-
     let mut cmd = std::process::Command::new("nimpretty");
 
     cmd.arg(snippet_path);

--- a/src/formatters/nixfmt.rs
+++ b/src/formatters/nixfmt.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_nixfmt(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("nixfmt");
-
     let mut cmd = std::process::Command::new("nixfmt");
 
     cmd.arg(snippet_path);

--- a/src/formatters/nixpkgs_fmt.rs
+++ b/src/formatters/nixpkgs_fmt.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_nixpkgs_fmt(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("nixpkgs-fmt");
-
     let mut cmd = std::process::Command::new("nixpkgs-fmt");
 
     cmd.arg(snippet_path);
@@ -22,7 +19,7 @@ mod test_nixpkgs_fmt {
     #[test_with::executable(nixpkgs-fmt)]
     #[test]
     fn it_should_format_nix() {
-        let input = r#"{ 
+        let input = r#"{
             lib, buildPythonPackage, fetchFromGitHub, redis }:
 
 buildPythonPackage rec {

--- a/src/formatters/npm_groovy_lint.rs
+++ b/src/formatters/npm_groovy_lint.rs
@@ -1,5 +1,5 @@
 use super::execute_command;
-use crate::{runners::setup_npm_script, terminal::print_formatter_info};
+use crate::runners::setup_npm_script;
 
 #[inline]
 fn set_npm_groovy_lint_args(cmd: &mut std::process::Command, snippet_path: &std::path::Path) {
@@ -21,8 +21,6 @@ fn invoke_npm_groovy_lint(
 pub fn format_using_npm_groovy_lint(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("npm-groovy-lint");
-
     let path_result =
         invoke_npm_groovy_lint(std::process::Command::new("npm-groovy-lint"), snippet_path)?;
 

--- a/src/formatters/ocamlformat.rs
+++ b/src/formatters/ocamlformat.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_ocamlformat(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("ocamlformat");
-
     let mut cmd = std::process::Command::new("ocamlformat");
 
     cmd.arg("--ignore-invalid-option")

--- a/src/formatters/ocp_indent.rs
+++ b/src/formatters/ocp_indent.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_ocp_indent(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("ocp-indent");
-
     let mut cmd = std::process::Command::new("ocp-indent");
 
     cmd.arg("--inplace").arg(snippet_path);

--- a/src/formatters/ormolu.rs
+++ b/src/formatters/ormolu.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_ormolu(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("ormolu");
-
     let mut cmd = std::process::Command::new("ormolu");
 
     cmd.arg("--mode").arg("inplace").arg(snippet_path);

--- a/src/formatters/perltidy.rs
+++ b/src/formatters/perltidy.rs
@@ -1,5 +1,4 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 fn set_perltidy_args(cmd: &mut std::process::Command, snippet_path: &std::path::Path) {
@@ -21,8 +20,6 @@ fn invoke_perltidy(
 pub fn format_using_perltidy(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("perltidy");
-
     invoke_perltidy(std::process::Command::new("perltidy"), snippet_path)
 }
 

--- a/src/formatters/prettier.rs
+++ b/src/formatters/prettier.rs
@@ -1,5 +1,5 @@
 use super::execute_command;
-use crate::{runners::setup_npm_script, terminal::print_formatter_info};
+use crate::runners::setup_npm_script;
 
 #[inline]
 fn set_prettier_args(
@@ -30,8 +30,6 @@ pub fn format_using_prettier(
     snippet_path: &std::path::Path,
     embedded_language_formatting: bool,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("prettier");
-
     let global_result = invoke_prettier(
         std::process::Command::new("prettier"),
         snippet_path,

--- a/src/formatters/purs_tidy.rs
+++ b/src/formatters/purs_tidy.rs
@@ -1,5 +1,5 @@
 use super::execute_command;
-use crate::{runners::setup_npm_script, terminal::print_formatter_info};
+use crate::runners::setup_npm_script;
 
 #[inline]
 fn set_purs_tidy_args(cmd: &mut std::process::Command, snippet_path: &std::path::Path) {
@@ -20,8 +20,6 @@ fn invoke_purs_tidy(
 pub fn format_using_purs_tidy(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("purs-tidy");
-
     invoke_purs_tidy(setup_npm_script("purs-tidy"), snippet_path)
 }
 

--- a/src/formatters/rescript_format.rs
+++ b/src/formatters/rescript_format.rs
@@ -1,5 +1,5 @@
 use super::execute_command;
-use crate::{runners::setup_npm_script, terminal::print_formatter_info};
+use crate::runners::setup_npm_script;
 
 #[inline]
 fn set_rescript_format_args(cmd: &mut std::process::Command, snippet_path: &std::path::Path) {
@@ -20,8 +20,6 @@ fn invote_rescript_format(
 pub fn format_using_rescript_format(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("rescript_format");
-
     invote_rescript_format(setup_npm_script("rescript"), snippet_path)
 }
 

--- a/src/formatters/roc_format.rs
+++ b/src/formatters/roc_format.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_roc_format(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("roc_format");
-
     let mut cmd = std::process::Command::new("roc");
 
     cmd.arg("format").arg(snippet_path);

--- a/src/formatters/rubocop.rs
+++ b/src/formatters/rubocop.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_rubocop(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("rubocop");
-
     let mut cmd = std::process::Command::new("rubocop");
 
     cmd.arg("--fix-layout")

--- a/src/formatters/rubyfmt.rs
+++ b/src/formatters/rubyfmt.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_rubyfmt(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("rubyfmt");
-
     let mut cmd = std::process::Command::new("rubyfmt");
 
     cmd.arg("-i").arg(snippet_path);

--- a/src/formatters/ruff.rs
+++ b/src/formatters/ruff.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_ruff(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("ruff");
-
     let mut cmd = std::process::Command::new("ruff");
 
     cmd.arg("format");

--- a/src/formatters/rufo.rs
+++ b/src/formatters/rufo.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_rufo(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("rufo");
-
     let mut cmd = std::process::Command::new("rufo");
 
     cmd.arg("--simple-exit").arg(snippet_path);

--- a/src/formatters/rustfmt.rs
+++ b/src/formatters/rustfmt.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_rustfmt(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("rustfmt");
-
     let mut cmd = std::process::Command::new("rustfmt");
 
     // Needed for async

--- a/src/formatters/scalafmt.rs
+++ b/src/formatters/scalafmt.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_scalafmt(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("scalafmt");
-
     let mut cmd = std::process::Command::new("scalafmt");
 
     #[cfg(test)]

--- a/src/formatters/shfmt.rs
+++ b/src/formatters/shfmt.rs
@@ -1,10 +1,7 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_shfmt(file_path: &std::path::Path) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("shfmt");
-
     let mut cmd = std::process::Command::new("shfmt");
 
     cmd.arg("--write").arg(file_path);

--- a/src/formatters/sql_formatter.rs
+++ b/src/formatters/sql_formatter.rs
@@ -1,5 +1,5 @@
 use super::execute_command;
-use crate::{runners::setup_npm_script, terminal::print_formatter_info};
+use crate::runners::setup_npm_script;
 
 #[inline]
 fn set_sql_formatter_args(cmd: &mut std::process::Command, snippet_path: &std::path::Path) {
@@ -20,8 +20,6 @@ fn invote_sql_formatter(
 pub fn format_using_sql_formatter(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("sql-formatter");
-
     invote_sql_formatter(setup_npm_script("sql-formatter"), snippet_path)
 }
 

--- a/src/formatters/sqlfluff.rs
+++ b/src/formatters/sqlfluff.rs
@@ -1,5 +1,4 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 fn set_sqlfluff_args(cmd: &mut std::process::Command, snippet_path: &std::path::Path) {
@@ -24,8 +23,6 @@ fn invote_sqlfluff(
 pub fn format_using_sqlfluff(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("sqlfluff");
-
     invote_sqlfluff(std::process::Command::new("sqlfluff"), snippet_path)
 }
 

--- a/src/formatters/standardjs.rs
+++ b/src/formatters/standardjs.rs
@@ -1,5 +1,5 @@
 use super::execute_command;
-use crate::{runners::setup_npm_script, terminal::print_formatter_info};
+use crate::runners::setup_npm_script;
 
 #[inline]
 fn set_standardjs_args(cmd: &mut std::process::Command, snippet_path: &std::path::Path) {
@@ -20,8 +20,6 @@ fn invoke_standardjs(
 pub fn format_using_standardjs(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("standardjs");
-
     let global_result = invoke_standardjs(std::process::Command::new("standard"), snippet_path)?;
 
     if !global_result.0 {

--- a/src/formatters/standardrb.rs
+++ b/src/formatters/standardrb.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_standardrb(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("standardrb");
-
     let mut cmd = std::process::Command::new("standardrb");
 
     cmd.arg("--fix").arg(snippet_path);

--- a/src/formatters/stylelint.rs
+++ b/src/formatters/stylelint.rs
@@ -1,5 +1,5 @@
 use super::execute_command;
-use crate::{runners::setup_npm_script, terminal::print_formatter_info};
+use crate::runners::setup_npm_script;
 
 #[inline]
 fn set_stylelint_args(cmd: &mut std::process::Command, snippet_path: &std::path::Path) {
@@ -20,8 +20,6 @@ fn invoke_stylelint(
 pub fn format_using_stylelint(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("stylelint");
-
     let global_result = invoke_stylelint(std::process::Command::new("stylelint"), snippet_path)?;
 
     if !global_result.0 {

--- a/src/formatters/stylish_haskell.rs
+++ b/src/formatters/stylish_haskell.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_stylish_haskell(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("stylish-haskell");
-
     let mut cmd = std::process::Command::new("stylish-haskell");
 
     cmd.arg("--inplace").arg(snippet_path);

--- a/src/formatters/stylua.rs
+++ b/src/formatters/stylua.rs
@@ -1,5 +1,5 @@
 use super::execute_command;
-use crate::{runners::setup_npm_script, terminal::print_formatter_info};
+use crate::runners::setup_npm_script;
 
 #[inline]
 fn set_stylua_args(cmd: &mut std::process::Command, snippet_path: &std::path::Path) {
@@ -21,8 +21,6 @@ fn invoke_stylua(
 pub fn format_using_stylua(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("stylua");
-
     let path_result = invoke_stylua(std::process::Command::new("stylua"), snippet_path)?;
 
     if !path_result.0 {

--- a/src/formatters/swift_format.rs
+++ b/src/formatters/swift_format.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_swift_format(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("swift-format");
-
     let mut cmd = std::process::Command::new("swift-format");
 
     cmd.arg("--in-place").arg(snippet_path);

--- a/src/formatters/swiftformat.rs
+++ b/src/formatters/swiftformat.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_swiftformat(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("swiftformat");
-
     let mut cmd = std::process::Command::new("swiftformat");
 
     cmd.arg("--quiet").arg(snippet_path);

--- a/src/formatters/taplo.rs
+++ b/src/formatters/taplo.rs
@@ -1,5 +1,5 @@
 use super::execute_command;
-use crate::{runners::setup_npm_script, terminal::print_formatter_info};
+use crate::runners::setup_npm_script;
 
 #[inline]
 fn set_taplo_args(cmd: &mut std::process::Command, snippet_path: &std::path::Path) {
@@ -21,8 +21,6 @@ fn invoke_taplo(
 pub fn format_using_taplo(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("taplo");
-
     let path_result = invoke_taplo(std::process::Command::new("taplo"), snippet_path)?;
 
     if !path_result.0 {

--- a/src/formatters/terraform_fmt.rs
+++ b/src/formatters/terraform_fmt.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_terraform_fmt(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("terraform_fmt");
-
     let mut cmd = std::process::Command::new("terraform");
 
     cmd.arg("fmt").arg("-write=true").arg(snippet_path);
@@ -22,7 +19,7 @@ mod test_terraform_fmt {
     #[test_with::executable(terraform)]
     #[test]
     fn it_should_format_hcl() {
-        let input = "resource \"aws_instance\" \"example\" {                
+        let input = "resource \"aws_instance\" \"example\" {
                     ami   = \"abc123\"
 
            network_interface  {

--- a/src/formatters/tofu_fmt.rs
+++ b/src/formatters/tofu_fmt.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_tofu_fmt(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("tofu_fmt");
-
     let mut cmd = std::process::Command::new("tofu");
 
     cmd.arg("fmt").arg("-write=true").arg(snippet_path);
@@ -22,7 +19,7 @@ mod test_tofu_fmt {
     #[test_with::executable(tofu)]
     #[test]
     fn it_should_format_hcl() {
-        let input = "resource \"aws_instance\" \"example\" {                
+        let input = "resource \"aws_instance\" \"example\" {
                 ami   = \"abc123\"
 
            network_interface  {

--- a/src/formatters/usort.rs
+++ b/src/formatters/usort.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_usort(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("usort");
-
     let mut cmd = std::process::Command::new("usort");
 
     cmd.arg("format").arg(snippet_path);

--- a/src/formatters/xmlformat.rs
+++ b/src/formatters/xmlformat.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_xmlformat(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("xmlformat");
-
     let mut cmd = std::process::Command::new("xmlformat");
 
     cmd.arg("--overwrite").arg(snippet_path);

--- a/src/formatters/xmllint.rs
+++ b/src/formatters/xmllint.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_xmllint(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("xmllint");
-
     let mut cmd = std::process::Command::new("xmllint");
 
     cmd.arg("--format")

--- a/src/formatters/yamlfix.rs
+++ b/src/formatters/yamlfix.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_yamlfix(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("yamlfix");
-
     let mut cmd = std::process::Command::new("yamlfix");
 
     cmd.arg(snippet_path);

--- a/src/formatters/yamlfmt.rs
+++ b/src/formatters/yamlfmt.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_yamlfmt(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("yamlfmt");
-
     let mut cmd = std::process::Command::new("yamlfmt");
 
     cmd.arg("-quiet").arg(snippet_path);

--- a/src/formatters/yapf.rs
+++ b/src/formatters/yapf.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_yapf(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("yapf");
-
     let mut cmd = std::process::Command::new("yapf");
 
     cmd.arg("--in-place").arg(snippet_path);

--- a/src/formatters/zigfmt.rs
+++ b/src/formatters/zigfmt.rs
@@ -1,12 +1,9 @@
 use super::execute_command;
-use crate::terminal::print_formatter_info;
 
 #[inline]
 pub fn format_using_zigfmt(
     snippet_path: &std::path::Path,
 ) -> std::io::Result<(bool, Option<String>)> {
-    print_formatter_info("zigfmt");
-
     let mut cmd = std::process::Command::new("zig");
 
     cmd.arg("fmt");

--- a/src/languages/blade.rs
+++ b/src/languages/blade.rs
@@ -3,8 +3,8 @@ use schemars::JsonSchema;
 use super::{Lang, LanguageFormatter};
 use crate::formatters::{blade_formatter::format_using_blade_formatter, MdsfFormatter};
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Blade {
     #[default]
     #[serde(rename = "blade-formatter")]
@@ -40,12 +40,22 @@ impl LanguageFormatter for Blade {
     }
 }
 
+impl core::fmt::Display for Blade {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::BladeFormatter => write!(f, "blade-formatter"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_blade {
     use super::Blade;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = r#"@extends('frontend.layouts.app')
@@ -95,7 +105,7 @@ mod test_blade {
             enabled: false,
             formatter: MdsfFormatter::Single(Blade::BladeFormatter),
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -143,7 +153,7 @@ mod test_blade {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/c.rs
+++ b/src/languages/c.rs
@@ -3,8 +3,8 @@ use schemars::JsonSchema;
 use super::{Lang, LanguageFormatter};
 use crate::formatters::{clang_format::format_using_clang_format, MdsfFormatter};
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum C {
     #[default]
     #[serde(rename = "clang-format")]
@@ -40,12 +40,22 @@ impl LanguageFormatter for C {
     }
 }
 
+impl core::fmt::Display for C {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::ClangFormat => write!(f, "clang-format"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_c {
     use super::C;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = "int add(int a,int b){
@@ -69,7 +79,7 @@ mod test_c {
             enabled: false,
             formatter: MdsfFormatter::Single(C::default()),
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -86,7 +96,7 @@ mod test_c {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/cabal.rs
+++ b/src/languages/cabal.rs
@@ -3,8 +3,8 @@ use schemars::JsonSchema;
 use super::{Lang, LanguageFormatter};
 use crate::formatters::{cabal_format::format_using_cabal_format, MdsfFormatter};
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Cabal {
     #[default]
     #[serde(rename = "cabal_format")]
@@ -40,21 +40,31 @@ impl LanguageFormatter for Cabal {
     }
 }
 
+impl core::fmt::Display for Cabal {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::CabalFormat => write!(f, "cabal_format"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_cabal {
     use super::Cabal;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT:&str = "cabal-version: 2.4
-name: mdsf 
+name: mdsf
 version: 0
 
-executable msdf 
+executable msdf
     default-language: Haskell2010
-    hs-source-dirs: src 
+    hs-source-dirs: src
     main-is: Mdsf.hs
     build-depends: base >=4.11 && <4.13, pretty >=1.1.3.6 && <1.2, bytestring, Cabal ^>=2.5, containers ^>=0.5.11.0 || ^>=0.6.0.1
     other-extensions:
@@ -78,7 +88,10 @@ executable msdf
         let snippet = setup_snippet(INPUT, EXTENSION).expect("it to save the file");
         let snippet_path = snippet.path();
 
-        assert!(l.format(snippet_path).expect("it to not fail").is_none());
+        assert!(l
+            .format(snippet_path, &LineInfo::fake())
+            .expect("it to not fail")
+            .is_none());
     }
 
     #[test]
@@ -92,7 +105,7 @@ executable msdf
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/clojure.rs
+++ b/src/languages/clojure.rs
@@ -3,8 +3,8 @@ use schemars::JsonSchema;
 use super::{Lang, LanguageFormatter};
 use crate::formatters::{cljstyle::format_using_cljstyle, MdsfFormatter};
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Clojure {
     #[default]
     #[serde(rename = "cljstyle")]
@@ -40,12 +40,22 @@ impl LanguageFormatter for Clojure {
     }
 }
 
+impl core::fmt::Display for Clojure {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Cljstyle => write!(f, "cljstyle"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_c {
     use super::Clojure;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = "(  ns
@@ -80,7 +90,7 @@ mod test_c {
             enabled: false,
             formatter: MdsfFormatter::Single(Clojure::default()),
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -97,7 +107,7 @@ mod test_c {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/cpp.rs
+++ b/src/languages/cpp.rs
@@ -3,8 +3,8 @@ use schemars::JsonSchema;
 use super::{Lang, LanguageFormatter};
 use crate::formatters::{clang_format::format_using_clang_format, MdsfFormatter};
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Cpp {
     #[default]
     #[serde(rename = "clang-format")]
@@ -40,12 +40,22 @@ impl LanguageFormatter for Cpp {
     }
 }
 
+impl core::fmt::Display for Cpp {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::ClangFormat => write!(f, "clang-format"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_cpp {
     use super::Cpp;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = "int add(int a,int b){
@@ -69,7 +79,7 @@ mod test_cpp {
             enabled: false,
             formatter: MdsfFormatter::Single(Cpp::default())
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -86,7 +96,7 @@ mod test_cpp {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/crystal.rs
+++ b/src/languages/crystal.rs
@@ -3,8 +3,8 @@ use schemars::JsonSchema;
 use super::{Lang, LanguageFormatter};
 use crate::formatters::{crystal_format::format_using_crystal_format, MdsfFormatter};
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Crystal {
     #[default]
     #[serde(rename = "crystal_format")]
@@ -40,12 +40,22 @@ impl LanguageFormatter for Crystal {
     }
 }
 
+impl core::fmt::Display for Crystal {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::CrystalFormat => write!(f, "crystal_format"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_crystal {
     use super::Crystal;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = "def add(a, b)  return a + b end";
@@ -66,7 +76,7 @@ mod test_crystal {
             enabled: false,
             formatter: MdsfFormatter::Single(Crystal::CrystalFormat),
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -87,7 +97,7 @@ end
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/csharp.rs
+++ b/src/languages/csharp.rs
@@ -5,8 +5,8 @@ use crate::formatters::{
     clang_format::format_using_clang_format, csharpier::format_using_csharpier, MdsfFormatter,
 };
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum CSharp {
     #[default]
     #[serde(rename = "csharpier")]
@@ -48,12 +48,23 @@ impl LanguageFormatter for CSharp {
     }
 }
 
+impl core::fmt::Display for CSharp {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::CSharpier => write!(f, "csharpier"),
+            Self::ClangFormat => write!(f, "clang-format"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_csharp {
     use super::CSharp;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = "namespace Mdsf {
@@ -81,7 +92,7 @@ mod test_csharp {
             enabled: false,
             formatter: MdsfFormatter::<CSharp>::default(),
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -98,7 +109,7 @@ mod test_csharp {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -126,7 +137,7 @@ class Adder {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/css.rs
+++ b/src/languages/css.rs
@@ -5,8 +5,8 @@ use crate::formatters::{
     prettier::format_using_prettier, stylelint::format_using_stylelint, MdsfFormatter,
 };
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Css {
     #[default]
     #[serde(rename = "prettier")]
@@ -45,12 +45,23 @@ impl LanguageFormatter for Css {
     }
 }
 
+impl core::fmt::Display for Css {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Prettier => write!(f, "prettier"),
+            Self::StyleLint => write!(f, "stylelint"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_css {
     use super::Css;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::{CssFlavor, Lang},
+        LineInfo,
     };
 
     const INPUT: &str = " h1   {color: blue;} p    {color: red;} ";
@@ -71,7 +82,7 @@ mod test_css {
             enabled: false,
             formatter: MdsfFormatter::Single(Css::default()),
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -87,7 +98,7 @@ mod test_css {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/dart.rs
+++ b/src/languages/dart.rs
@@ -3,8 +3,8 @@ use schemars::JsonSchema;
 use super::{Lang, LanguageFormatter};
 use crate::formatters::{dart_format::format_using_dart_format, MdsfFormatter};
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Dart {
     #[default]
     #[serde(rename = "dart_format")]
@@ -40,12 +40,22 @@ impl LanguageFormatter for Dart {
     }
 }
 
+impl core::fmt::Display for Dart {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::DartFormat => write!(f, "dart_format"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_dart {
     use super::Dart;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = "class Adder {   int add(int a, int b) {     return a + b;   } }    ";
@@ -66,7 +76,7 @@ mod test_dart {
             enabled: false,
             formatter: MdsfFormatter::Single(Dart::default(),)
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -83,7 +93,7 @@ mod test_dart {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/elixir.rs
+++ b/src/languages/elixir.rs
@@ -3,8 +3,8 @@ use schemars::JsonSchema;
 use super::{Lang, LanguageFormatter};
 use crate::formatters::{mix_format::format_using_mix_format, MdsfFormatter};
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Elixir {
     #[default]
     #[serde(rename = "mix_format")]
@@ -40,12 +40,22 @@ impl LanguageFormatter for Elixir {
     }
 }
 
+impl core::fmt::Display for Elixir {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::MixFormat => write!(f, "mix_format"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_elixir {
     use super::Elixir;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = "
@@ -69,7 +79,7 @@ mod test_elixir {
             enabled: false,
             formatter: MdsfFormatter::Single(Elixir::default()),
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -86,7 +96,7 @@ mod test_elixir {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/elm.rs
+++ b/src/languages/elm.rs
@@ -3,8 +3,8 @@ use schemars::JsonSchema;
 use super::{Lang, LanguageFormatter};
 use crate::formatters::{elm_format::format_using_elm_format, MdsfFormatter};
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Elm {
     #[default]
     #[serde(rename = "elm-format")]
@@ -40,12 +40,22 @@ impl LanguageFormatter for Elm {
     }
 }
 
+impl core::fmt::Display for Elm {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::ElmFormat => write!(f, "elm-format"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_elm {
     use super::Elm;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = r#"import   Html       exposing   (text)
@@ -73,7 +83,7 @@ main =
             enabled: false,
             formatter: MdsfFormatter::Single(Elm::default())
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -89,7 +99,7 @@ main =
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
         let expected_output = r#"module Main exposing (main)

--- a/src/languages/erlang.rs
+++ b/src/languages/erlang.rs
@@ -3,8 +3,8 @@ use schemars::JsonSchema;
 use super::{Lang, LanguageFormatter};
 use crate::formatters::{efmt::format_using_efmt, erlfmt::format_using_erlfmt, MdsfFormatter};
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Erlang {
     #[default]
     #[serde(rename = "erlfmt")]
@@ -43,12 +43,23 @@ impl LanguageFormatter for Erlang {
     }
 }
 
+impl core::fmt::Display for Erlang {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Efmt => write!(f, "efmt"),
+            Self::Erlfmt => write!(f, "erlfmt"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_erlang {
     use super::Erlang;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = "what_is(Erlang) ->
@@ -71,7 +82,7 @@ case Erlang of movie->[hello(mike,joe,robert),credits]; language->formatting_arg
             enabled: false,
             formatter: MdsfFormatter::Single(Erlang::default())
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -88,7 +99,7 @@ case Erlang of movie->[hello(mike,joe,robert),credits]; language->formatting_arg
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -117,7 +128,7 @@ case Erlang of movie->[hello(mike,joe,robert),credits]; language->formatting_arg
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/fsharp.rs
+++ b/src/languages/fsharp.rs
@@ -3,8 +3,8 @@ use schemars::JsonSchema;
 use super::{Lang, LanguageFormatter};
 use crate::formatters::{fantomas::format_using_fantomas, MdsfFormatter};
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum FSharp {
     #[default]
     #[serde(rename = "fantomas")]
@@ -40,16 +40,26 @@ impl LanguageFormatter for FSharp {
     }
 }
 
+impl core::fmt::Display for FSharp {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Fantomas => write!(f, "fantomas"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_fsharp {
     use super::FSharp;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = "
-let add  a b   =  
+let add  a b   =
                                                       a +  b
             ";
     const EXTENSION: &str = crate::languages::Language::FSharp.to_file_ext();
@@ -68,7 +78,7 @@ let add  a b   =
             enabled: false,
             formatter: MdsfFormatter::<FSharp>::default(),
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -85,7 +95,7 @@ let add  a b   =
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/gleam.rs
+++ b/src/languages/gleam.rs
@@ -3,8 +3,8 @@ use schemars::JsonSchema;
 use super::{Lang, LanguageFormatter};
 use crate::formatters::{gleam_format::format_using_gleam_format, MdsfFormatter};
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Gleam {
     #[default]
     #[serde(rename = "gleam_format")]
@@ -40,12 +40,22 @@ impl LanguageFormatter for Gleam {
     }
 }
 
+impl core::fmt::Display for Gleam {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::GleamFormat => write!(f, "gleam_format"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_gleam {
     use super::Gleam;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = "pub fn add(a:Int,b:Int)->Int{a+b}";
@@ -66,7 +76,7 @@ mod test_gleam {
             enabled: false,
             formatter: MdsfFormatter::Single(Gleam::default())
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -83,7 +93,7 @@ mod test_gleam {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/go.rs
+++ b/src/languages/go.rs
@@ -6,8 +6,8 @@ use crate::formatters::{
     MdsfFormatter,
 };
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Go {
     #[default]
     #[serde(rename = "gofmt")]
@@ -52,12 +52,24 @@ impl LanguageFormatter for Go {
     }
 }
 
+impl core::fmt::Display for Go {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::GoFmt => write!(f, "gofmt"),
+            Self::GoFumpt => write!(f, "gofumpt"),
+            Self::GoImports => write!(f, "goimports"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_go {
     use super::Go;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = "package main
@@ -84,7 +96,7 @@ mod test_go {
             enabled: false,
             formatter: MdsfFormatter::<Go>::default(),
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -101,7 +113,7 @@ mod test_go {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -127,7 +139,7 @@ func add(a int, b int) int {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -180,7 +192,7 @@ func add(a int, b int) int {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/graphql.rs
+++ b/src/languages/graphql.rs
@@ -3,8 +3,8 @@ use schemars::JsonSchema;
 use super::{Lang, LanguageFormatter};
 use crate::formatters::{prettier::format_using_prettier, MdsfFormatter};
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum GraphQL {
     #[default]
     #[serde(rename = "prettier")]
@@ -40,16 +40,26 @@ impl LanguageFormatter for GraphQL {
     }
 }
 
+impl core::fmt::Display for GraphQL {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Prettier => write!(f, "prettier"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_grapql {
     use super::GraphQL;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
-    const INPUT: &str = "{   hero {     name     
-                # Queries can have comments!    
+    const INPUT: &str = "{   hero {     name
+                # Queries can have comments!
          friends {       name     }   } }";
 
     const EXTENSION: &str = crate::languages::Language::GraphQL.to_file_ext();
@@ -68,7 +78,7 @@ mod test_grapql {
             enabled: false,
             formatter: MdsfFormatter::Single(GraphQL::default()),
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -95,7 +105,7 @@ mod test_grapql {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/groovy.rs
+++ b/src/languages/groovy.rs
@@ -3,8 +3,8 @@ use schemars::JsonSchema;
 use super::{Lang, LanguageFormatter};
 use crate::formatters::{npm_groovy_lint::format_using_npm_groovy_lint, MdsfFormatter};
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Groovy {
     #[default]
     #[serde(rename = "npm-groovy-lint")]
@@ -40,16 +40,26 @@ impl LanguageFormatter for Groovy {
     }
 }
 
+impl core::fmt::Display for Groovy {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::NpmGroovyLint => write!(f, "npm-groovy-lint"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_groovy {
     use super::Groovy;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = "        def add(a, b) {
-            return a + b 
+            return a + b
         }
 
         assert add(1,2) == 3            ";
@@ -71,7 +81,10 @@ mod test_groovy {
         let snippet = setup_snippet(INPUT, EXTENSION).expect("it to save the file");
         let snippet_path = snippet.path();
 
-        assert!(l.format(snippet_path).expect("it to not fail").is_none());
+        assert!(l
+            .format(snippet_path, &LineInfo::fake())
+            .expect("it to not fail")
+            .is_none());
     }
 
     #[test]
@@ -85,7 +98,7 @@ mod test_groovy {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/haskell.rs
+++ b/src/languages/haskell.rs
@@ -6,8 +6,8 @@ use crate::formatters::{
     stylish_haskell::format_using_stylish_haskell, MdsfFormatter,
 };
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Haskell {
     #[serde(rename = "fourmolu")]
     Fourmolu,
@@ -56,18 +56,31 @@ impl LanguageFormatter for Haskell {
     }
 }
 
+impl core::fmt::Display for Haskell {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Fourmolu => write!(f, "fourmolu"),
+            Self::Ormolu => write!(f, "ormolu"),
+            Self::HIndent => write!(f, "hundent"),
+            Self::StylishHaskell => write!(f, "stylish-haskell"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_haskell {
     use super::Haskell;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = "
 addNumbers::Int->Int->Int
-addNumbers a b = do 
-        a + b 
+addNumbers a b = do
+        a + b
         ";
 
     const EXTENSION: &str = crate::languages::Language::Haskell.to_file_ext();
@@ -86,7 +99,7 @@ addNumbers a b = do
             enabled: false,
             formatter: MdsfFormatter::Single(Haskell::default()),
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -103,7 +116,7 @@ addNumbers a b = do
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -127,7 +140,7 @@ addNumbers a b = do
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -151,7 +164,7 @@ addNumbers a b = do
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -175,7 +188,7 @@ addNumbers a b = do
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/hcl.rs
+++ b/src/languages/hcl.rs
@@ -5,8 +5,8 @@ use crate::formatters::{
     terraform_fmt::format_using_terraform_fmt, tofu_fmt::format_using_tofu_fmt, MdsfFormatter,
 };
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Hcl {
     #[default]
     #[serde(rename = "terraform_fmt")]
@@ -48,15 +48,26 @@ impl LanguageFormatter for Hcl {
     }
 }
 
+impl core::fmt::Display for Hcl {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::TerraformFmt => write!(f, "terraform_fmt"),
+            Self::TofuFmt => write!(f, "tofu_fmt"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_hcl {
     use super::Hcl;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
-    const INPUT: &str = "resource \"aws_instance\" \"example\" {                         
+    const INPUT: &str = "resource \"aws_instance\" \"example\" {
                                          ami   = \"abc123\"
 
            network_interface  {
@@ -80,7 +91,7 @@ mod test_hcl {
             enabled: false,
             formatter: MdsfFormatter::Single(Hcl::default()),
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -97,7 +108,7 @@ mod test_hcl {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -124,7 +135,7 @@ mod test_hcl {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/html.rs
+++ b/src/languages/html.rs
@@ -3,8 +3,8 @@ use schemars::JsonSchema;
 use super::{Lang, LanguageFormatter};
 use crate::formatters::{prettier::format_using_prettier, MdsfFormatter};
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Html {
     #[default]
     #[serde(rename = "prettier")]
@@ -40,12 +40,22 @@ impl LanguageFormatter for Html {
     }
 }
 
+impl core::fmt::Display for Html {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Prettier => write!(f, "prettier"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_html {
     use super::Html;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str =  " <!doctype html> <html> <head> <style> body {background-color: powderblue;} h1   {color: blue;} p    {color: red;} </style> </head> <body>  <h1>This is a heading</h1> <p>This is a paragraph.</p>  </body> </html> ";
@@ -66,7 +76,7 @@ mod test_html {
             enabled: false,
             formatter: MdsfFormatter::Single(Html::default()),
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -104,7 +114,7 @@ mod test_html {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/java.rs
+++ b/src/languages/java.rs
@@ -6,8 +6,8 @@ use crate::formatters::{
     MdsfFormatter,
 };
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Java {
     #[default]
     #[serde(rename = "google-java-format")]
@@ -49,12 +49,23 @@ impl LanguageFormatter for Java {
     }
 }
 
+impl core::fmt::Display for Java {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::GoogleJavaFormat => write!(f, "google-java-format"),
+            Self::ClangFormat => write!(f, "clang-format"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_java {
     use super::Java;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = "class HelloWorld {
@@ -80,7 +91,7 @@ mod test_java {
             enabled: false,
             formatter: MdsfFormatter::Single(Java::default()),
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -103,7 +114,7 @@ mod test_java {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -129,7 +140,7 @@ mod test_java {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/javascript.rs
+++ b/src/languages/javascript.rs
@@ -7,8 +7,8 @@ use crate::formatters::{
     standardjs::format_using_standardjs, MdsfFormatter,
 };
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum JavaScript {
     #[default]
     #[serde(rename = "prettier")]
@@ -61,12 +61,26 @@ impl LanguageFormatter for JavaScript {
     }
 }
 
+impl core::fmt::Display for JavaScript {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Prettier => write!(f, "prettier"),
+            Self::Biome => write!(f, "biome"),
+            Self::DenoFmt => write!(f, "deno_fmt"),
+            Self::ClangFormat => write!(f, "clang-format"),
+            Self::Standardjs => write!(f, "standardjs"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_javascript {
     use super::JavaScript;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::{JavaScriptFlavor, Lang},
+        LineInfo,
     };
 
     const INPUT: &str = "
@@ -98,7 +112,7 @@ mod test_javascript {
         };
 
         assert!(prettier
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .is_none());
 
@@ -108,7 +122,7 @@ mod test_javascript {
         };
 
         assert!(biome
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .is_none());
     }
@@ -124,7 +138,7 @@ mod test_javascript {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -147,7 +161,7 @@ mod test_javascript {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -178,7 +192,7 @@ mod test_javascript {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -205,7 +219,7 @@ mod test_javascript {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -240,7 +254,7 @@ console.info(asyncAddition(1, 2))
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/json.rs
+++ b/src/languages/json.rs
@@ -6,8 +6,8 @@ use crate::formatters::{
     deno_fmt::format_using_deno_fmt, prettier::format_using_prettier, MdsfFormatter,
 };
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Json {
     #[default]
     #[serde(rename = "prettier")]
@@ -57,12 +57,25 @@ impl LanguageFormatter for Json {
     }
 }
 
+impl core::fmt::Display for Json {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Prettier => write!(f, "prettier"),
+            Self::Biome => write!(f, "biome"),
+            Self::DenoFmt => write!(f, "deno_fmt"),
+            Self::ClangFormat => write!(f, "clang-format"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_json {
     use super::Json;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::{JsonFlavor, Lang},
+        LineInfo,
     };
 
     const INPUT: &str = "{
@@ -91,7 +104,7 @@ mod test_json {
             enabled: false,
             formatter: MdsfFormatter::<Json>::default(),
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -107,7 +120,7 @@ mod test_json {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -131,7 +144,7 @@ mod test_json {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -156,7 +169,7 @@ mod test_json {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -186,7 +199,7 @@ mod test_json {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/julia.rs
+++ b/src/languages/julia.rs
@@ -3,8 +3,8 @@ use schemars::JsonSchema;
 use super::{Lang, LanguageFormatter};
 use crate::formatters::{juliaformatter_jl::format_using_juliaformatter_jl, MdsfFormatter};
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Julia {
     #[default]
     #[serde(rename = "juliaformatter.jl")]
@@ -40,17 +40,27 @@ impl LanguageFormatter for Julia {
     }
 }
 
+impl core::fmt::Display for Julia {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::JuliaFormatterJl => write!(f, "juliaformatter.jl"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_julia {
     use super::Julia;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = "function add( a:: Int32,  b::Int32 )
-            c = a+ b  
-            return c 
+            c = a+ b
+            return c
             end ";
 
     const EXTENSION: &str = crate::languages::Language::Julia.to_file_ext();
@@ -69,7 +79,7 @@ mod test_julia {
             enabled: false,
             formatter: MdsfFormatter::Single(Julia::default()),
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -86,7 +96,7 @@ mod test_julia {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/just.rs
+++ b/src/languages/just.rs
@@ -3,8 +3,8 @@ use schemars::JsonSchema;
 use super::{Lang, LanguageFormatter};
 use crate::formatters::{just_fmt::format_using_just_fmt, MdsfFormatter};
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Just {
     #[default]
     #[serde(rename = "just_fmt")]
@@ -40,12 +40,22 @@ impl LanguageFormatter for Just {
     }
 }
 
+impl core::fmt::Display for Just {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::JustFmt => write!(f, "just_fmt"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_just {
     use super::Just;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = "
@@ -71,7 +81,7 @@ build:
             enabled: false,
             formatter: MdsfFormatter::Single(Just::default())
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -88,7 +98,7 @@ build:
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/kotlin.rs
+++ b/src/languages/kotlin.rs
@@ -3,8 +3,8 @@ use schemars::JsonSchema;
 use super::{Lang, LanguageFormatter};
 use crate::formatters::{ktfmt::format_using_ktfmt, ktlint::format_using_ktlint, MdsfFormatter};
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Kotlin {
     #[default]
     #[serde(rename = "ktlint")]
@@ -46,12 +46,23 @@ impl LanguageFormatter for Kotlin {
     }
 }
 
+impl core::fmt::Display for Kotlin {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Ktlint => write!(f, "ktlint"),
+            Self::Ktfmt => write!(f, "ktfmt"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_kotlin {
     use super::Kotlin;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = "  fun add(a:Int ,b:Int ):Int {
@@ -75,7 +86,7 @@ mod test_kotlin {
             enabled: false,
             formatter: MdsfFormatter::Single(Kotlin::default())
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -92,7 +103,7 @@ mod test_kotlin {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -121,7 +132,7 @@ fun add(
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/lua.rs
+++ b/src/languages/lua.rs
@@ -5,13 +5,12 @@ use crate::formatters::{
     luaformatter::format_using_luaformatter, stylua::format_using_stylua, MdsfFormatter,
 };
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Lua {
     #[default]
     #[serde(rename = "stylua")]
     Stylua,
-
     #[serde(rename = "luaformatter")]
     LuaFormatter,
 }
@@ -49,20 +48,31 @@ impl LanguageFormatter for Lua {
     }
 }
 
+impl core::fmt::Display for Lua {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Stylua => write!(f, "stylua"),
+            Self::LuaFormatter => write!(f, "luaformatter"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_lua {
     use super::Lua;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = "
 
         local               function        add (                                       a , b
 )
-    local c =  a  + b 
-return              c 
+    local c =  a  + b
+return              c
 
 
 end
@@ -84,7 +94,7 @@ end
             enabled: false,
             formatter: MdsfFormatter::Single(Lua::default()),
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -106,7 +116,7 @@ end
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -132,7 +142,7 @@ end
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/markdown.rs
+++ b/src/languages/markdown.rs
@@ -3,12 +3,21 @@ use schemars::JsonSchema;
 use super::{Lang, LanguageFormatter};
 use crate::formatters::{prettier::format_using_prettier, MdsfFormatter};
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Markdown {
     #[default]
     #[serde(rename = "prettier")]
     Prettier,
+}
+
+impl core::fmt::Display for Markdown {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Prettier => write!(f, "prettier"),
+        }
+    }
 }
 
 impl Default for Lang<Markdown> {
@@ -46,6 +55,7 @@ mod test_markdown {
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = "
@@ -71,7 +81,7 @@ mod test_markdown {
             enabled: false,
             formatter: MdsfFormatter::<Markdown>::default(),
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -92,7 +102,7 @@ the whitespace should be removed
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -1,6 +1,6 @@
 use schemars::JsonSchema;
 
-use crate::{formatters::MdsfFormatter, LineInfo};
+use crate::{formatters::MdsfFormatter, terminal::print_formatter_info, LineInfo};
 
 pub mod blade;
 pub mod c;
@@ -263,7 +263,6 @@ pub trait LanguageFormatter {
     fn format_snippet(
         &self,
         snippet_path: &std::path::Path,
-        info: &LineInfo,
     ) -> std::io::Result<(bool, Option<String>)>;
 }
 
@@ -402,28 +401,28 @@ impl Language {
     }
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub struct Lang<T>
 where
-    T: LanguageFormatter,
+    T: LanguageFormatter + core::fmt::Display,
 {
     pub enabled: bool,
     pub formatter: MdsfFormatter<T>,
 }
 
-impl<T: LanguageFormatter> Lang<T> {
+impl<T: LanguageFormatter + core::fmt::Display> Lang<T> {
     #[inline]
     pub fn format(
         &self,
         snippet_path: &std::path::Path,
-        info: LineInfo,
+        info: &LineInfo,
     ) -> std::io::Result<Option<String>> {
         if !self.enabled {
             return Ok(None);
         }
 
-        Self::format_multiple(&self.formatter, snippet_path, &info, false)
+        Self::format_multiple(&self.formatter, snippet_path, info, false)
             .map(|(_should_continue, output)| output)
     }
 
@@ -435,7 +434,11 @@ impl<T: LanguageFormatter> Lang<T> {
         nested: bool,
     ) -> std::io::Result<(bool, Option<String>)> {
         match formatter {
-            MdsfFormatter::Single(f) => f.format_snippet(snippet_path, info),
+            MdsfFormatter::Single(f) => {
+                print_formatter_info(f.to_string().as_str(), info);
+
+                f.format_snippet(snippet_path)
+            }
 
             MdsfFormatter::Multiple(formatters) => {
                 let mut r = Ok((true, None));
@@ -462,8 +465,12 @@ mod test_lang {
     use std::io::Write;
 
     use super::{Lang, LanguageFormatter};
-    use crate::formatters::{setup_snippet, MdsfFormatter};
+    use crate::{
+        formatters::{setup_snippet, MdsfFormatter},
+        LineInfo,
+    };
 
+    #[derive(serde::Serialize)]
     enum TestLanguage {
         A,
         B,
@@ -471,6 +478,18 @@ mod test_lang {
         // Will fail
         D,
         E,
+    }
+
+    impl core::fmt::Display for TestLanguage {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            match self {
+                Self::A => write!(f, "A"),
+                Self::B => write!(f, "B"),
+                Self::C => write!(f, "C"),
+                Self::D => write!(f, "D"),
+                Self::E => write!(f, "E"),
+            }
+        }
     }
 
     impl LanguageFormatter for TestLanguage {
@@ -505,7 +524,7 @@ mod test_lang {
         let snippet_path = file.path();
 
         let code = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to be ok")
             .expect("it to be some");
 
@@ -528,7 +547,7 @@ mod test_lang {
         let snippet_path = file.path();
 
         let code = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to be ok")
             .expect("it to be some");
 
@@ -557,7 +576,7 @@ mod test_lang {
         let snippet_path = file.path();
 
         let code = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to be ok")
             .expect("it to be some");
 

--- a/src/languages/nim.rs
+++ b/src/languages/nim.rs
@@ -3,8 +3,8 @@ use schemars::JsonSchema;
 use super::{Lang, LanguageFormatter};
 use crate::formatters::{nimpretty::format_using_nimpretty, MdsfFormatter};
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Nim {
     #[default]
     #[serde(rename = "nimpretty")]
@@ -40,12 +40,22 @@ impl LanguageFormatter for Nim {
     }
 }
 
+impl core::fmt::Display for Nim {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Nimpretty => write!(f, "nimpretty"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_nim {
     use super::Nim;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = "proc           add( a         :int , b:int )        : int =
@@ -67,7 +77,7 @@ mod test_nim {
             enabled: false,
             formatter: MdsfFormatter::Single(Nim::default()),
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -84,7 +94,7 @@ mod test_nim {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/nix.rs
+++ b/src/languages/nix.rs
@@ -6,8 +6,8 @@ use crate::formatters::{
     nixpkgs_fmt::format_using_nixpkgs_fmt, MdsfFormatter,
 };
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Nix {
     #[default]
     #[serde(rename = "nixfmt")]
@@ -53,16 +53,27 @@ impl LanguageFormatter for Nix {
     }
 }
 
+impl core::fmt::Display for Nix {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Alejandra => write!(f, "alejandra"),
+            Self::Nixfmt => write!(f, "nixfmt"),
+            Self::NixpkgsFmt => write!(f, "nixpkgs-fmt"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_nix {
-
     use super::Nix;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
-    const INPUT: &str = r#"{ 
+    const INPUT: &str = r#"{
             lib, buildPythonPackage, fetchFromGitHub, redis }:
 
 buildPythonPackage rec {
@@ -106,7 +117,7 @@ buildPythonPackage rec {
             enabled: false,
             formatter: MdsfFormatter::Single(Nix::default()),
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -150,7 +161,7 @@ buildPythonPackage rec {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -169,7 +180,7 @@ buildPythonPackage rec {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -249,7 +260,7 @@ buildPythonPackage rec {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/objective_c.rs
+++ b/src/languages/objective_c.rs
@@ -3,8 +3,8 @@ use schemars::JsonSchema;
 use super::{Lang, LanguageFormatter};
 use crate::formatters::{clang_format::format_using_clang_format, MdsfFormatter};
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum ObjectiveC {
     #[default]
     #[serde(rename = "clang-format")]
@@ -40,12 +40,22 @@ impl LanguageFormatter for ObjectiveC {
     }
 }
 
+impl core::fmt::Display for ObjectiveC {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::ClangFormat => write!(f, "clang-format"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_objective_c {
     use super::ObjectiveC;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = "int add(int a,int b){
@@ -69,7 +79,7 @@ mod test_objective_c {
             enabled: false,
             formatter: MdsfFormatter::Single(ObjectiveC::ClangFormat),
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -91,7 +101,7 @@ mod test_objective_c {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/ocaml.rs
+++ b/src/languages/ocaml.rs
@@ -5,8 +5,8 @@ use crate::formatters::{
     ocamlformat::format_using_ocamlformat, ocp_indent::format_using_ocp_indent, MdsfFormatter,
 };
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum OCaml {
     #[default]
     #[serde(rename = "ocamlformat")]
@@ -48,12 +48,23 @@ impl LanguageFormatter for OCaml {
     }
 }
 
+impl core::fmt::Display for OCaml {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::OCamlFormat => write!(f, "ocamlformat"),
+            Self::OcpIndent => write!(f, "ocpindent"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_ocaml {
     use super::OCaml;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = "
@@ -76,7 +87,7 @@ let add a b  =  a +  b
             enabled: false,
             formatter: MdsfFormatter::Single(OCaml::default())
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -93,7 +104,7 @@ let add a b  =  a +  b
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -124,7 +135,7 @@ let add a b
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/perl.rs
+++ b/src/languages/perl.rs
@@ -3,8 +3,8 @@ use schemars::JsonSchema;
 use super::{Lang, LanguageFormatter};
 use crate::formatters::{perltidy::format_using_perltidy, MdsfFormatter};
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Perl {
     #[default]
     #[serde(rename = "perltidy")]
@@ -40,12 +40,22 @@ impl LanguageFormatter for Perl {
     }
 }
 
+impl core::fmt::Display for Perl {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::PerlTidy => write!(f, "perltidy"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_perl {
     use super::Perl;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = r#"$_= <<'EOL';
@@ -76,7 +86,10 @@ print(" MiXeD"),redo LOOP if/\G[A-Za-z]+\b[,.;]?\s*/gc;print(
         let snippet = setup_snippet(INPUT, EXTENSION).expect("it to save the file");
         let snippet_path = snippet.path();
 
-        assert!(l.format(snippet_path).expect("it to not fail").is_none());
+        assert!(l
+            .format(snippet_path, &LineInfo::fake())
+            .expect("it to not fail")
+            .is_none());
     }
 
     #[test_with::executable(perltidy)]
@@ -91,7 +104,7 @@ print(" MiXeD"),redo LOOP if/\G[A-Za-z]+\b[,.;]?\s*/gc;print(
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/protobuf.rs
+++ b/src/languages/protobuf.rs
@@ -5,8 +5,8 @@ use crate::formatters::{
     buf::format_using_buf, clang_format::format_using_clang_format, MdsfFormatter,
 };
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Protobuf {
     #[default]
     #[serde(rename = "buf")]
@@ -48,12 +48,23 @@ impl LanguageFormatter for Protobuf {
     }
 }
 
+impl core::fmt::Display for Protobuf {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Buf => write!(f, "buf"),
+            Self::ClangFormat => write!(f, "clang-format"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_protobuf {
     use super::Protobuf;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = "service SearchService {
@@ -76,7 +87,7 @@ mod test_protobuf {
             enabled: false,
             formatter: MdsfFormatter::Single(Protobuf::default()),
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -98,7 +109,7 @@ mod test_protobuf {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -120,7 +131,7 @@ mod test_protobuf {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/purescript.rs
+++ b/src/languages/purescript.rs
@@ -3,8 +3,8 @@ use schemars::JsonSchema;
 use super::{Lang, LanguageFormatter};
 use crate::formatters::{purs_tidy::format_using_purs_tidy, MdsfFormatter};
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum PureScript {
     #[default]
     #[serde(rename = "purs-tidy")]
@@ -40,12 +40,22 @@ impl LanguageFormatter for PureScript {
     }
 }
 
+impl core::fmt::Display for PureScript {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::PursTidy => write!(f, "purs-tidy"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_purescript {
     use super::PureScript;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = r#"module       Test.Main   where
@@ -75,7 +85,7 @@ main   =    do
             enabled: false,
             formatter: MdsfFormatter::Single(PureScript::default())
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -91,7 +101,7 @@ main   =    do
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/python.rs
+++ b/src/languages/python.rs
@@ -7,8 +7,8 @@ use crate::formatters::{
     yapf::format_using_yapf, MdsfFormatter,
 };
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Python {
     #[default]
     #[serde(rename = "ruff")]
@@ -74,12 +74,28 @@ impl Default for Lang<Python> {
     }
 }
 
+impl core::fmt::Display for Python {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Ruff => write!(f, "ruff"),
+            Self::Black => write!(f, "black"),
+            Self::Yapf => write!(f, "yapf"),
+            Self::Blue => write!(f, "blue"),
+            Self::Autopep8 => write!(f, "autopep8"),
+            Self::Isort => write!(f, "isort"),
+            Self::Usort => write!(f, "usort"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_python {
     use super::Python;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = "def add( a: int ,  b:int)->int: return a+b";
@@ -100,7 +116,7 @@ mod test_python {
             enabled: false,
             formatter: MdsfFormatter::Single(Python::default()),
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -119,7 +135,7 @@ mod test_python {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -140,7 +156,7 @@ mod test_python {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -161,7 +177,7 @@ mod test_python {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -182,7 +198,7 @@ mod test_python {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -203,7 +219,7 @@ mod test_python {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -242,7 +258,7 @@ def add(a: int, b: int) -> int:
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -281,7 +297,7 @@ def add(a: int, b: int) -> int:
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/rescript.rs
+++ b/src/languages/rescript.rs
@@ -3,8 +3,8 @@ use schemars::JsonSchema;
 use super::{Lang, LanguageFormatter};
 use crate::formatters::{rescript_format::format_using_rescript_format, MdsfFormatter};
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum ReScript {
     #[default]
     #[serde(rename = "rescript_format")]
@@ -40,12 +40,22 @@ impl LanguageFormatter for ReScript {
     }
 }
 
+impl core::fmt::Display for ReScript {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::ReScriptFormat => write!(f, "rescript_format"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_rescript {
     use super::ReScript;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = r#"module Button = {
@@ -78,7 +88,7 @@ mod test_rescript {
             enabled: false,
             formatter: MdsfFormatter::Single(ReScript::default())
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -94,7 +104,7 @@ mod test_rescript {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/roc.rs
+++ b/src/languages/roc.rs
@@ -3,8 +3,8 @@ use schemars::JsonSchema;
 use super::{Lang, LanguageFormatter};
 use crate::formatters::{roc_format::format_using_roc_format, MdsfFormatter};
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Roc {
     #[default]
     #[serde(rename = "roc_format")]
@@ -40,12 +40,22 @@ impl LanguageFormatter for Roc {
     }
 }
 
+impl core::fmt::Display for Roc {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::RocFormat => write!(f, "roc_format"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_roc {
     use super::Roc;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = r#"app "helloWorld"
@@ -80,7 +90,7 @@ main =
             enabled: false,
             formatter: MdsfFormatter::Single(Roc::default()),
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -97,7 +107,7 @@ main =
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/ruby.rs
+++ b/src/languages/ruby.rs
@@ -6,8 +6,8 @@ use crate::formatters::{
     standardrb::format_using_standardrb, MdsfFormatter,
 };
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Ruby {
     #[default]
     #[serde(rename = "rubyfmt")]
@@ -57,12 +57,25 @@ impl LanguageFormatter for Ruby {
     }
 }
 
+impl core::fmt::Display for Ruby {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::RubyFmt => write!(f, "rubyfmt"),
+            Self::RuboCop => write!(f, "rubocop"),
+            Self::Rufo => write!(f, "rufo"),
+            Self::Standardrb => write!(f, "standardrb"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_ruby {
     use super::Ruby;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str =
@@ -86,7 +99,7 @@ mod test_ruby {
             enabled: false,
             formatter: MdsfFormatter::default(),
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -108,7 +121,7 @@ end
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -132,7 +145,7 @@ end
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -156,7 +169,7 @@ end
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/rust.rs
+++ b/src/languages/rust.rs
@@ -3,8 +3,8 @@ use schemars::JsonSchema;
 use super::{Lang, LanguageFormatter};
 use crate::formatters::{rustfmt::format_using_rustfmt, MdsfFormatter};
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Rust {
     #[default]
     #[serde(rename = "rustfmt")]
@@ -40,12 +40,22 @@ impl LanguageFormatter for Rust {
     }
 }
 
+impl core::fmt::Display for Rust {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::RustFmt => write!(f, "rustfmt"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_rust {
     use super::Rust;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = "pub
@@ -70,7 +80,7 @@ mod test_rust {
             enabled: false,
             formatter: MdsfFormatter::Single(Rust::RustFmt),
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -89,7 +99,7 @@ mod test_rust {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/scala.rs
+++ b/src/languages/scala.rs
@@ -3,8 +3,8 @@ use schemars::JsonSchema;
 use super::{Lang, LanguageFormatter};
 use crate::formatters::{scalafmt::format_using_scalafmt, MdsfFormatter};
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Scala {
     #[default]
     #[serde(rename = "scalafmt")]
@@ -40,12 +40,22 @@ impl LanguageFormatter for Scala {
     }
 }
 
+impl core::fmt::Display for Scala {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Scalafmt => write!(f, "scalafmt"),
+        }
+    }
+}
+
 #[cfg(test)]
-mod test_blade {
+mod test_scala {
     use super::Scala;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = r#"
@@ -71,7 +81,7 @@ mod test_blade {
             enabled: false,
             formatter: MdsfFormatter::Single(Scala::Scalafmt),
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -93,7 +103,7 @@ mod test_blade {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/shell.rs
+++ b/src/languages/shell.rs
@@ -5,8 +5,8 @@ use crate::formatters::{
     beautysh::format_using_beautysh, shfmt::format_using_shfmt, MdsfFormatter,
 };
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Shell {
     #[default]
     #[serde(rename = "shfmt")]
@@ -35,6 +35,16 @@ impl Default for MdsfFormatter<Shell> {
     }
 }
 
+impl core::fmt::Display for Shell {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Shfmt => write!(f, "shfmt"),
+            Self::Beautysh => write!(f, "beautysh"),
+        }
+    }
+}
+
 impl LanguageFormatter for Shell {
     #[inline]
     fn format_snippet(
@@ -54,6 +64,7 @@ mod test_shell {
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::{Lang, ShellFlavor},
+        LineInfo,
     };
 
     const INPUT: &str = "
@@ -89,7 +100,7 @@ mod test_shell {
             enabled: false,
             formatter: MdsfFormatter::Single(Shell::Shfmt),
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -113,7 +124,7 @@ add() {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -145,7 +156,7 @@ add() {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/sql.rs
+++ b/src/languages/sql.rs
@@ -5,14 +5,24 @@ use crate::formatters::{
     sql_formatter::format_using_sql_formatter, sqlfluff::format_using_sqlfluff, MdsfFormatter,
 };
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Sql {
     #[default]
     #[serde(rename = "sqlfluff")]
     Sqlfluff,
     #[serde(rename = "sql-formatter")]
     SQLFormatter,
+}
+
+impl core::fmt::Display for Sql {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Sqlfluff => write!(f, "qqlfluff"),
+            Self::SQLFormatter => write!(f, "sql-formatter"),
+        }
+    }
 }
 
 impl Default for Lang<Sql> {
@@ -50,11 +60,11 @@ impl LanguageFormatter for Sql {
 
 #[cfg(test)]
 mod test_sql {
-
     use super::Sql;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = "SELECT  *                  FROM  tbl
@@ -76,7 +86,7 @@ mod test_sql {
             enabled: false,
             formatter: MdsfFormatter::Single(Sql::SQLFormatter),
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
 
@@ -84,7 +94,7 @@ mod test_sql {
             enabled: false,
             formatter: MdsfFormatter::Single(Sql::Sqlfluff),
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -108,7 +118,7 @@ WHERE
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -131,7 +141,7 @@ WHERE foo = 'bar';
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/swift.rs
+++ b/src/languages/swift.rs
@@ -5,8 +5,8 @@ use crate::formatters::{
     swift_format::format_using_swift_format, swiftformat::format_using_swiftformat, MdsfFormatter,
 };
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Swift {
     #[default]
     #[serde(rename = "swift-format")]
@@ -48,16 +48,27 @@ impl LanguageFormatter for Swift {
     }
 }
 
+impl core::fmt::Display for Swift {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::AppleSwiftFormat => write!(f, "swift-format"),
+            Self::NicklockwoodSwiftFormat => write!(f, "swiftformat"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_swift {
     use super::Swift;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = " func add(a:Int ,b:Int)->Int {
-    return a + b     
+    return a + b
     }";
 
     const EXTENSION: &str = crate::languages::Language::Swift.to_file_ext();
@@ -76,7 +87,7 @@ mod test_swift {
             enabled: false,
             formatter: MdsfFormatter::Single(Swift::default()),
         }
-        .format(snippet_path)
+        .format(snippet_path, &LineInfo::fake())
         .expect("it to not fail")
         .is_none());
     }
@@ -93,7 +104,7 @@ mod test_swift {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -117,7 +128,7 @@ mod test_swift {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/toml.rs
+++ b/src/languages/toml.rs
@@ -3,8 +3,8 @@ use schemars::JsonSchema;
 use super::{Lang, LanguageFormatter};
 use crate::formatters::{taplo::format_using_taplo, MdsfFormatter};
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Toml {
     #[default]
     #[serde(rename = "taplo")]
@@ -40,12 +40,22 @@ impl LanguageFormatter for Toml {
     }
 }
 
+impl core::fmt::Display for Toml {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Taplo => write!(f, "taplo"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_toml {
     use super::Toml;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = "          package         =              \"mdsf\"
@@ -69,7 +79,10 @@ mod test_toml {
         let snippet = setup_snippet(INPUT, EXTENSION).expect("it to save the file");
         let snippet_path = snippet.path();
 
-        assert!(l.format(snippet_path).expect("it to not fail").is_none());
+        assert!(l
+            .format(snippet_path, &LineInfo::fake())
+            .expect("it to not fail")
+            .is_none());
     }
 
     #[test]
@@ -83,7 +96,7 @@ mod test_toml {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/typescript.rs
+++ b/src/languages/typescript.rs
@@ -6,8 +6,8 @@ use crate::formatters::{
     MdsfFormatter,
 };
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum TypeScript {
     #[default]
     #[serde(rename = "prettier")]
@@ -53,11 +53,23 @@ impl LanguageFormatter for TypeScript {
     }
 }
 
+impl core::fmt::Display for TypeScript {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Prettier => write!(f, "prettier"),
+            Self::Biome => write!(f, "biome"),
+            Self::DenoFmt => write!(f, "deno_fmt"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_typescript {
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::{typescript::TypeScript, Lang, TypeScriptFlavor},
+        LineInfo,
     };
 
     const INPUT: &str = "
@@ -90,7 +102,7 @@ number>
         };
 
         assert!(prettier
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .is_none());
 
@@ -100,7 +112,7 @@ number>
         };
 
         assert!(biome
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .is_none());
     }
@@ -116,7 +128,7 @@ number>
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -140,7 +152,7 @@ number>
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -165,7 +177,7 @@ number>
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/vue.rs
+++ b/src/languages/vue.rs
@@ -3,8 +3,8 @@ use schemars::JsonSchema;
 use super::{Lang, LanguageFormatter};
 use crate::formatters::{prettier::format_using_prettier, MdsfFormatter};
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Vue {
     #[default]
     #[serde(rename = "prettier")]
@@ -40,12 +40,22 @@ impl LanguageFormatter for Vue {
     }
 }
 
+impl core::fmt::Display for Vue {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Prettier => write!(f, "prettier"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_vue {
     use super::Vue;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = "<script lang=\"ts\"   setup >
@@ -84,7 +94,10 @@ import {
         let snippet = setup_snippet(INPUT, EXTENSION).expect("it to save the file");
         let snippet_path = snippet.path();
 
-        assert!(l.format(snippet_path).expect("it to not fail").is_none());
+        assert!(l
+            .format(snippet_path, &LineInfo::fake())
+            .expect("it to not fail")
+            .is_none());
     }
 
     #[test]
@@ -98,7 +111,7 @@ import {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/xml.rs
+++ b/src/languages/xml.rs
@@ -5,8 +5,8 @@ use crate::formatters::{
     xmlformat::format_using_xmlformat, xmllint::format_using_xmllint, MdsfFormatter,
 };
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Xml {
     #[default]
     #[serde(rename = "xmllint")]
@@ -48,12 +48,23 @@ impl LanguageFormatter for Xml {
     }
 }
 
+impl core::fmt::Display for Xml {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::XmlLint => write!(f, "xmllint"),
+            Self::XmlFormat => write!(f, "xmlformat"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_xml {
     use super::Xml;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = "
@@ -81,7 +92,10 @@ mod test_xml {
         let snippet = setup_snippet(INPUT, EXTENSION).expect("it to save the file");
         let snippet_path = snippet.path();
 
-        assert!(l.format(snippet_path).expect("it to not fail").is_none());
+        assert!(l
+            .format(snippet_path, &LineInfo::fake())
+            .expect("it to not fail")
+            .is_none());
     }
 
     #[test_with::executable(xmllint)]
@@ -96,7 +110,7 @@ mod test_xml {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -124,7 +138,7 @@ mod test_xml {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/yaml.rs
+++ b/src/languages/yaml.rs
@@ -6,8 +6,8 @@ use crate::formatters::{
     MdsfFormatter,
 };
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Yaml {
     #[default]
     #[serde(rename = "prettier")]
@@ -53,12 +53,24 @@ impl LanguageFormatter for Yaml {
     }
 }
 
+impl core::fmt::Display for Yaml {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Prettier => write!(f, "prettier"),
+            Self::YamlFmt => write!(f, "yamlfmt"),
+            Self::YamlFix => write!(f, "yamlfix"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_yaml {
     use super::Yaml;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = "
@@ -102,7 +114,10 @@ updates:
         let snippet = setup_snippet(INPUT, EXTENSION).expect("it to save the file");
         let snippet_path = snippet.path();
 
-        assert!(l.format(snippet_path).expect("it to not fail").is_none());
+        assert!(l
+            .format(snippet_path, &LineInfo::fake())
+            .expect("it to not fail")
+            .is_none());
     }
 
     #[test]
@@ -116,7 +131,7 @@ updates:
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -154,7 +169,7 @@ updates:
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 
@@ -191,7 +206,7 @@ updates:
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/languages/zig.rs
+++ b/src/languages/zig.rs
@@ -3,8 +3,8 @@ use schemars::JsonSchema;
 use super::{Lang, LanguageFormatter};
 use crate::formatters::{zigfmt::format_using_zigfmt, MdsfFormatter};
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Default, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Zig {
     #[default]
     #[serde(rename = "zigfmt")]
@@ -40,12 +40,22 @@ impl LanguageFormatter for Zig {
     }
 }
 
+impl core::fmt::Display for Zig {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::ZigFmt => write!(f, "zigfmt"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_zig {
     use super::Zig;
     use crate::{
         formatters::{setup_snippet, MdsfFormatter},
         languages::Lang,
+        LineInfo,
     };
 
     const INPUT: &str = "
@@ -72,7 +82,10 @@ mod test_zig {
         let snippet = setup_snippet(INPUT, EXTENSION).expect("it to save the file");
         let snippet_path = snippet.path();
 
-        assert!(l.format(snippet_path).expect("it to not fail").is_none());
+        assert!(l
+            .format(snippet_path, &LineInfo::fake())
+            .expect("it to not fail")
+            .is_none());
     }
 
     #[test_with::executable(zig)]
@@ -87,7 +100,7 @@ mod test_zig {
         let snippet_path = snippet.path();
 
         let output = l
-            .format(snippet_path)
+            .format(snippet_path, &LineInfo::fake())
             .expect("it to not fail")
             .expect("it to be a snippet");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ fn format_file(config: &MdsfConfig, filename: &std::path::Path, input: &str) -> 
                 if is_snippet {
                     let formatted = format_snippet(
                         config,
-                        LineInfo {
+                        &LineInfo {
                             filename,
                             language,
                             start: line_index + 1,
@@ -84,7 +84,7 @@ fn format_file(config: &MdsfConfig, filename: &std::path::Path, input: &str) -> 
     if config.format_finished_document && !output.is_empty() {
         output = format_snippet(
             config,
-            LineInfo {
+            &LineInfo {
                 filename,
                 language: Language::Markdown,
                 start: 0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use mdsf::{
     config::MdsfConfig,
     error::MdsfError,
     handle_file,
-    terminal::print_error,
+    terminal::{blankline, logging::setup_logger, print_error},
 };
 
 fn format_command(args: FormatCommandArguments) -> Result<(), MdsfError> {
@@ -28,6 +28,7 @@ fn format_command(args: FormatCommandArguments) -> Result<(), MdsfError> {
 
             if file_path.extension() == Some(&OsStr::from("md")) {
                 handle_file(&conf, file_path)?;
+                blankline()
             }
         }
     } else {
@@ -67,7 +68,11 @@ fn generate_schema_command() -> std::io::Result<()> {
 
 fn main() {
     let command_result = match Cli::parse().command {
-        Commands::Format(args) => format_command(args),
+        Commands::Format(args) => {
+            setup_logger(args.log_level);
+
+            format_command(args)
+        }
         Commands::Init => init_config_command().map_err(MdsfError::from),
         Commands::Schema => generate_schema_command().map_err(MdsfError::from),
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use mdsf::{
     config::MdsfConfig,
     error::MdsfError,
     handle_file,
-    terminal::{blankline, logging::setup_logger, print_error},
+    terminal::{logging::setup_logger, print_error},
 };
 
 fn format_command(args: FormatCommandArguments) -> Result<(), MdsfError> {
@@ -28,7 +28,6 @@ fn format_command(args: FormatCommandArguments) -> Result<(), MdsfError> {
 
             if file_path.extension() == Some(&OsStr::from("md")) {
                 handle_file(&conf, file_path)?;
-                blankline()
             }
         }
     } else {

--- a/src/runners/mod.rs
+++ b/src/runners/mod.rs
@@ -3,7 +3,7 @@ use core::sync::atomic::{AtomicU8, Ordering};
 use schemars::JsonSchema;
 
 use self::{bun::new_bunx_cmd, deno::new_deno_cmd, node::new_npx_cmd};
-use crate::terminal::{print_javascript_runtime, print_unknown_javascript_runtime};
+use crate::terminal::print_unknown_javascript_runtime;
 
 mod bun;
 mod deno;
@@ -82,8 +82,6 @@ fn get_javascript_runtime() -> JavaScriptRuntime {
 #[inline]
 pub fn setup_npm_script(package_name: &str) -> std::process::Command {
     let runtime = get_javascript_runtime();
-
-    print_javascript_runtime(runtime);
 
     match runtime {
         JavaScriptRuntime::Bun => new_bunx_cmd(package_name),

--- a/src/terminal/logging.rs
+++ b/src/terminal/logging.rs
@@ -1,0 +1,64 @@
+use std::io::Write;
+
+use console::style;
+use log::LevelFilter;
+
+use crate::cli::LogLevel;
+
+impl From<LogLevel> for LevelFilter {
+    fn from(value: LogLevel) -> Self {
+        match value {
+            LogLevel::Off => Self::Off,
+            LogLevel::Error => Self::Error,
+            LogLevel::Warn => Self::Warn,
+            LogLevel::Info => Self::Info,
+            LogLevel::Debug => Self::Debug,
+        }
+    }
+}
+
+pub fn setup_logger(log_level: LogLevel) {
+    env_logger::Builder::from_env("MDSF_LOG")
+        .filter(None, LevelFilter::Off)
+        .filter_module("mdsf::terminal", log_level.into())
+        .format_timestamp(None)
+        .format_module_path(false)
+        .format_target(false)
+        .format_level(false)
+        .format(move |buf, record| {
+            let x = 0;
+
+            match record.level() {
+                log::Level::Error => writeln!(
+                    buf,
+                    "{}{} {}",
+                    style("error").red().bold(),
+                    style(":").bold(),
+                    record.args()
+                ),
+                log::Level::Warn => writeln!(
+                    buf,
+                    "{}{} {}",
+                    style("warn").yellow().bold(),
+                    style(":").bold(),
+                    record.args()
+                ),
+                log::Level::Info => writeln!(buf, "{}", record.args()),
+                log::Level::Debug => writeln!(buf, "{}", style(format!("{}", record.args())).dim()),
+                log::Level::Trace => writeln!(buf, "{}", style(format!("{}", record.args())).dim()),
+            }
+            /*
+                    let tag = match record.level() {
+                        log::Level::Error => style("e").red(),
+                        log::Level::Warn => style("w").yellow(),
+                        log::Level::Info => style("i").green(),
+                        log::Level::Debug => style("d").cyan(),
+                        log::Level::Trace => style("t").magenta(),
+                    }
+                    .bold();
+
+                    writeln!(buf, "{}{} {}", tag, style(":").bold(), record.args())
+            */
+        })
+        .init();
+}

--- a/src/terminal/logging.rs
+++ b/src/terminal/logging.rs
@@ -6,6 +6,7 @@ use log::LevelFilter;
 use crate::cli::LogLevel;
 
 impl From<LogLevel> for LevelFilter {
+    #[inline]
     fn from(value: LogLevel) -> Self {
         match value {
             LogLevel::Off => Self::Off,
@@ -13,10 +14,12 @@ impl From<LogLevel> for LevelFilter {
             LogLevel::Warn => Self::Warn,
             LogLevel::Info => Self::Info,
             LogLevel::Debug => Self::Debug,
+            LogLevel::Trace => Self::Trace,
         }
     }
 }
 
+#[inline]
 pub fn setup_logger(log_level: LogLevel) {
     env_logger::Builder::from_env("MDSF_LOG")
         .filter(None, LevelFilter::Off)
@@ -25,40 +28,17 @@ pub fn setup_logger(log_level: LogLevel) {
         .format_module_path(false)
         .format_target(false)
         .format_level(false)
-        .format(move |buf, record| {
-            let x = 0;
-
-            match record.level() {
-                log::Level::Error => writeln!(
-                    buf,
-                    "{}{} {}",
-                    style("error").red().bold(),
-                    style(":").bold(),
-                    record.args()
-                ),
-                log::Level::Warn => writeln!(
-                    buf,
-                    "{}{} {}",
-                    style("warn").yellow().bold(),
-                    style(":").bold(),
-                    record.args()
-                ),
-                log::Level::Info => writeln!(buf, "{}", record.args()),
-                log::Level::Debug => writeln!(buf, "{}", style(format!("{}", record.args())).dim()),
-                log::Level::Trace => writeln!(buf, "{}", style(format!("{}", record.args())).dim()),
+        .format(move |buf, record| match record.level() {
+            log::Level::Error => writeln!(buf, "{}", style(format!("{}", record.args())).red()),
+            log::Level::Warn => writeln!(
+                buf,
+                "{}",
+                style(format!("{}", record.args())).yellow().bold()
+            ),
+            log::Level::Info => writeln!(buf, "{}", record.args()),
+            log::Level::Debug | log::Level::Trace => {
+                writeln!(buf, "{}", style(format!("{}", record.args())).dim())
             }
-            /*
-                    let tag = match record.level() {
-                        log::Level::Error => style("e").red(),
-                        log::Level::Warn => style("w").yellow(),
-                        log::Level::Info => style("i").green(),
-                        log::Level::Debug => style("d").cyan(),
-                        log::Level::Trace => style("t").magenta(),
-                    }
-                    .bold();
-
-                    writeln!(buf, "{}{} {}", tag, style(":").bold(), record.args())
-            */
         })
         .init();
 }

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -1,3 +1,4 @@
+use console::style;
 use log::{debug, error, info, warn};
 
 use crate::{error::MdsfError, runners::JavaScriptRuntime, LineInfo};
@@ -22,12 +23,20 @@ pub fn print_formatter_info(formatter: &str, info: &LineInfo) {
 
 #[inline]
 pub fn print_unchanged_file(path: &std::path::Path, dur: core::time::Duration) {
-    info!("{} {}ms (unchanged)", path.display(), dur.as_millis());
+    info!(
+        "{}",
+        style(format!(
+            "{} finished in {}ms (unchanged)\n",
+            path.display(),
+            dur.as_millis()
+        ))
+        .dim()
+    );
 }
 
 #[inline]
 pub fn print_changed_line(path: &std::path::Path, dur: core::time::Duration) {
-    info!("{} {}ms", path.display(), dur.as_millis());
+    info!("{} finished in {}ms\n", path.display(), dur.as_millis());
 }
 
 #[inline]

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -1,93 +1,46 @@
-use crate::{error::MdsfError, languages::Language, runners::JavaScriptRuntime, DEBUG};
+use log::{debug, error, info, warn};
 
-#[cfg(target_os = "windows")]
-const GREY_TEXT: &str = "";
-#[cfg(not(target_os = "windows"))]
-const GREY_TEXT: &str = "\u{1b}[2m";
+use crate::{error::MdsfError, runners::JavaScriptRuntime, LineInfo};
 
-#[cfg(target_os = "windows")]
-const DEBUG_TEXT_DECORATION: &str = "";
-#[cfg(not(target_os = "windows"))]
-const DEBUG_TEXT_DECORATION: &str = "\u{1b}[33m";
-
-#[cfg(target_os = "windows")]
-const ERROR_TEXT_DECORATION: &str = "";
-#[cfg(not(target_os = "windows"))]
-const ERROR_TEXT_DECORATION: &str = "\u{1b}[31m";
-
-#[cfg(target_os = "windows")]
-const TEXT_RESET: &str = "";
-#[cfg(not(target_os = "windows"))]
-const TEXT_RESET: &str = "\u{1b}[0m";
+pub mod logging;
 
 #[inline]
 pub fn print_error(error: &MdsfError) {
-    println!("{ERROR_TEXT_DECORATION}{error}{TEXT_RESET}");
+    error!("{error}");
 }
 
 #[inline]
-pub fn print_debug<T: core::fmt::Display>(args: T) {
-    if DEBUG.load(core::sync::atomic::Ordering::Relaxed) {
-        println!("{DEBUG_TEXT_DECORATION}{args}{TEXT_RESET}");
-    }
-}
-
-#[inline]
-pub fn print_file_info(filename: &std::path::Path) {
-    print_debug(format!("Formatting '{}'", filename.display()));
-}
-
-#[inline]
-pub fn print_line_info(language: Language, start: usize, end: usize) {
-    print_debug(format!(
-        "Formatting '{language}' block from :{start} to :{end}"
-    ));
-}
-
-#[inline]
-pub fn print_formatter_info(formatter: &str) {
-    print_debug(format!("Using formatter: '{formatter}'"));
-}
-
-#[inline]
-pub fn print_unchanged_file(path: &std::path::Path, dur: core::time::Duration) {
-    println!(
-        "{GREY_TEXT}{} {}ms (unchanged){TEXT_RESET}",
-        path.display(),
-        dur.as_millis()
+pub fn print_formatter_info(formatter: &str, info: &LineInfo) {
+    debug!(
+        "{} formatting '{}' block from :{} to :{} using {formatter}",
+        info.filename.display(),
+        info.language,
+        info.start,
+        info.end
     );
 }
 
 #[inline]
-pub fn print_changed_line(path: &std::path::Path, dur: core::time::Duration) {
-    println!("{} {}ms", path.display(), dur.as_millis());
+pub fn print_unchanged_file(path: &std::path::Path, dur: core::time::Duration) {
+    info!("{} {}ms (unchanged)", path.display(), dur.as_millis());
 }
 
 #[inline]
-pub fn print_config_info(maybe_config_path: Option<&std::path::Path>) {
-    if let Some(config_path) = maybe_config_path {
-        print_debug(format!(
-            "{DEBUG_TEXT_DECORATION}Using config found at '{}'{TEXT_RESET}",
-            config_path.display()
-        ));
-    } else {
-        print_debug("Using default config since no config was found");
-    }
+pub fn print_changed_line(path: &std::path::Path, dur: core::time::Duration) {
+    info!("{} {}ms", path.display(), dur.as_millis());
+}
+
+#[inline]
+pub fn print_config_not_found() {
+    warn!("Using default config since no config was found");
 }
 
 #[inline]
 pub fn print_unknown_javascript_runtime(value: u8, fallback: JavaScriptRuntime) {
-    print_debug(format!(
-        "Unknown JavaScript runtime value '{value}'; Using {fallback:?} instead"
-    ));
-}
-
-#[inline]
-pub fn print_javascript_runtime(runtime: JavaScriptRuntime) {
-    print_debug(format!("Using JavaScript runtime '{runtime}'"));
+    warn!("Unknown JavaScript runtime value '{value}'; Using {fallback:?} instead");
 }
 
 #[inline]
 pub fn print_binary_not_in_path(binary_name: &str) {
-    print_debug(format!("'{binary_name}' not found in path"));
+    warn!("'{binary_name}' not found in path");
 }


### PR DESCRIPTION
Implement argument for log level (`--log-level`) instead of relying on `--debug`.

![image](https://github.com/hougesen/mdsf/assets/56034786/f01d0a25-c8a3-4e95-8d6d-afd49f7e7291)


Should close #167 and move #158 a forward. 