### PR TITLE
refactor(prettier): enable embed fmt based on ft

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -206,8 +206,8 @@ jobs:
       - name: yamlfix
         run: pipx install yamlfix && yamlfix --version
 
-      - name: terraform
-        run: wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg && echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list && sudo apt update && sudo apt install terraform && terraform -version
+      # - name: terraform
+      #  run: wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg && echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list && sudo apt update && sudo apt install terraform && terraform -version
 
       - name: nixfmt
         run: wget https://github.com/NixOS/nixfmt/releases/download/v0.6.0/nixfmt-x86_64-linux && chmod +x nixfmt-x86_64-linux && sudo cp nixfmt-x86_64-linux /usr/local/bin/nixfmt && nixfmt --version

--- a/src/formatters/prettier.rs
+++ b/src/formatters/prettier.rs
@@ -31,8 +31,9 @@ fn invoke_prettier(
 #[inline]
 pub fn format_using_prettier(
     snippet_path: &std::path::Path,
-    embedded_language_formatting: bool,
 ) -> Result<(bool, Option<String>), MdsfError> {
+    let embedded_language_formatting = snippet_path.extension().is_some_and(|ext| ext != "md");
+
     if let Ok(path_result) = invoke_prettier(
         std::process::Command::new("prettier"),
         snippet_path,
@@ -81,7 +82,7 @@ mod test_prettier {
         let snippet = setup_snippet(input, Language::Json(JsonFlavor::Json).to_file_ext())
             .expect("it to create a snippet file");
 
-        let output = format_using_prettier(snippet.path(), true)
+        let output = format_using_prettier(snippet.path())
             .expect("it to be successful")
             .1
             .expect("it to be some");
@@ -111,7 +112,7 @@ mod test_prettier {
         )
         .expect("it to create a snippet file");
 
-        let output = format_using_prettier(snippet.path(), true)
+        let output = format_using_prettier(snippet.path())
             .expect("it to be successful")
             .1
             .expect("it to be some");
@@ -144,7 +145,7 @@ number>
         )
         .expect("it to create a snippet file");
 
-        let output = format_using_prettier(snippet.path(), true)
+        let output = format_using_prettier(snippet.path())
             .expect("it to be successful")
             .1
             .expect("it to be some");
@@ -171,7 +172,7 @@ this is a paragraph
         let snippet = setup_snippet(input, Language::Markdown.to_file_ext())
             .expect("it to create a snippet file");
 
-        let output = format_using_prettier(snippet.path(), false)
+        let output = format_using_prettier(snippet.path())
             .expect("it to be successful")
             .1
             .expect("it to be some");
@@ -198,7 +199,7 @@ number>
         let snippet = setup_snippet(input, Language::Markdown.to_file_ext())
             .expect("it to create a snippet file");
 
-        let output = format_using_prettier(snippet.path(), false)
+        let output = format_using_prettier(snippet.path())
             .expect("it to be successful")
             .1
             .expect("it to be some");
@@ -235,7 +236,7 @@ number>
         let snippet = setup_snippet(input, Language::Html.to_file_ext())
             .expect("it to create a snippet file");
 
-        let output = format_using_prettier(snippet.path(), true)
+        let output = format_using_prettier(snippet.path())
             .expect("it to be successful")
             .1
             .expect("it to be some");
@@ -258,7 +259,7 @@ p {
         let snippet = setup_snippet(input, Language::Css(CssFlavor::Css).to_file_ext())
             .expect("it to create a snippet file");
 
-        let output = format_using_prettier(snippet.path(), true)
+        let output = format_using_prettier(snippet.path())
             .expect("it to be successful")
             .1
             .expect("it to be some");
@@ -314,7 +315,7 @@ updates:
         let snippet = setup_snippet(input, Language::Yaml.to_file_ext())
             .expect("it to create a snippet file");
 
-        let output = format_using_prettier(snippet.path(), false)
+        let output = format_using_prettier(snippet.path())
             .expect("it to be successful")
             .1
             .expect("it to be some");
@@ -360,7 +361,7 @@ function add(a: number, b: number): number {
         let snippet =
             setup_snippet(input, Language::Vue.to_file_ext()).expect("it to create a snippet file");
 
-        let output = format_using_prettier(snippet.path(), true)
+        let output = format_using_prettier(snippet.path())
             .expect("it to be successful")
             .1
             .expect("it to be some");
@@ -388,7 +389,7 @@ function add(a: number, b: number): number {
         let snippet = setup_snippet(input, Language::GraphQL.to_file_ext())
             .expect("it to create a snippet file");
 
-        let output = format_using_prettier(snippet.path(), true)
+        let output = format_using_prettier(snippet.path())
             .expect("it to be successful")
             .1
             .expect("it to be some");

--- a/src/languages/css.rs
+++ b/src/languages/css.rs
@@ -42,7 +42,7 @@ impl LanguageFormatter for Css {
         snippet_path: &std::path::Path,
     ) -> Result<(bool, Option<String>), MdsfError> {
         match self {
-            Self::Prettier => format_using_prettier(snippet_path, true),
+            Self::Prettier => format_using_prettier(snippet_path),
             Self::StyleLint => format_using_stylelint(snippet_path),
         }
     }

--- a/src/languages/graphql.rs
+++ b/src/languages/graphql.rs
@@ -38,7 +38,7 @@ impl LanguageFormatter for GraphQL {
         snippet_path: &std::path::Path,
     ) -> Result<(bool, Option<String>), MdsfError> {
         match self {
-            Self::Prettier => format_using_prettier(snippet_path, true),
+            Self::Prettier => format_using_prettier(snippet_path),
         }
     }
 }

--- a/src/languages/html.rs
+++ b/src/languages/html.rs
@@ -38,7 +38,7 @@ impl LanguageFormatter for Html {
         snippet_path: &std::path::Path,
     ) -> Result<(bool, Option<String>), MdsfError> {
         match self {
-            Self::Prettier => format_using_prettier(snippet_path, true),
+            Self::Prettier => format_using_prettier(snippet_path),
         }
     }
 }

--- a/src/languages/javascript.rs
+++ b/src/languages/javascript.rs
@@ -56,7 +56,7 @@ impl LanguageFormatter for JavaScript {
     ) -> Result<(bool, Option<String>), MdsfError> {
         match self {
             Self::Biome => format_using_biome(snippet_path),
-            Self::Prettier => format_using_prettier(snippet_path, true),
+            Self::Prettier => format_using_prettier(snippet_path),
             Self::ClangFormat => format_using_clang_format(snippet_path),
             Self::DenoFmt => format_using_deno_fmt(snippet_path),
             Self::Standardjs => format_using_standardjs(snippet_path),

--- a/src/languages/json.rs
+++ b/src/languages/json.rs
@@ -53,7 +53,7 @@ impl LanguageFormatter for Json {
     ) -> Result<(bool, Option<String>), MdsfError> {
         match self {
             Self::Biome => format_using_biome(snippet_path),
-            Self::Prettier => format_using_prettier(snippet_path, true),
+            Self::Prettier => format_using_prettier(snippet_path),
             Self::ClangFormat => format_using_clang_format(snippet_path),
             Self::DenoFmt => format_using_deno_fmt(snippet_path),
         }

--- a/src/languages/markdown.rs
+++ b/src/languages/markdown.rs
@@ -47,7 +47,7 @@ impl LanguageFormatter for Markdown {
         snippet_path: &std::path::Path,
     ) -> Result<(bool, Option<String>), MdsfError> {
         match self {
-            Self::Prettier => format_using_prettier(snippet_path, false),
+            Self::Prettier => format_using_prettier(snippet_path),
         }
     }
 }

--- a/src/languages/typescript.rs
+++ b/src/languages/typescript.rs
@@ -50,7 +50,7 @@ impl LanguageFormatter for TypeScript {
     ) -> Result<(bool, Option<String>), MdsfError> {
         match self {
             Self::Biome => format_using_biome(snippet_path),
-            Self::Prettier => format_using_prettier(snippet_path, true),
+            Self::Prettier => format_using_prettier(snippet_path),
             Self::DenoFmt => format_using_deno_fmt(snippet_path),
         }
     }

--- a/src/languages/vue.rs
+++ b/src/languages/vue.rs
@@ -38,7 +38,7 @@ impl LanguageFormatter for Vue {
         snippet_path: &std::path::Path,
     ) -> Result<(bool, Option<String>), MdsfError> {
         match self {
-            Self::Prettier => format_using_prettier(snippet_path, true),
+            Self::Prettier => format_using_prettier(snippet_path),
         }
     }
 }

--- a/src/languages/yaml.rs
+++ b/src/languages/yaml.rs
@@ -49,7 +49,7 @@ impl LanguageFormatter for Yaml {
         snippet_path: &std::path::Path,
     ) -> Result<(bool, Option<String>), MdsfError> {
         match self {
-            Self::Prettier => format_using_prettier(snippet_path, true),
+            Self::Prettier => format_using_prettier(snippet_path),
             Self::YamlFmt => format_using_yamlfmt(snippet_path),
             Self::YamlFix => format_using_yamlfix(snippet_path),
         }


### PR DESCRIPTION
Enable embedded_language_formatting if file is not markdown