### PR TITLE
feat: add line between stderr output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,6 +341,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "terminal_size",
  "test-with",
  "which 6.0.1",
 ]
@@ -559,6 +560,16 @@ dependencies = [
  "fastrand",
  "rustix",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+dependencies = [
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ schemars = { version = "0.8.21", optional = true }
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.118"
 tempfile = "3.10.1"
+terminal_size = "0.3.0"
 which = "6.0.1"
 
 [dev-dependencies]

--- a/codegen/Cargo.lock
+++ b/codegen/Cargo.lock
@@ -720,6 +720,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "terminal_size",
  "which",
 ]
 
@@ -1293,6 +1294,16 @@ dependencies = [
  "fastrand",
  "rustix",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+dependencies = [
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,7 @@ pub enum MdsfError {
     ConfigParse(std::path::PathBuf),
     // TODO: use &std::path::Path
     FileNotFound(std::path::PathBuf),
-    FormatterError,
+    FormatterError(String),
     // TODO: use &str
     MissingBinary(String),
     CheckModeChanges(u32),
@@ -28,7 +28,15 @@ impl core::fmt::Display for MdsfError {
                 "No file or directory with the name '{}' found",
                 path.display()
             ),
-            Self::FormatterError => write!(f, "Error formatting codeblock"),
+            Self::FormatterError(stderr) => {
+                let trimmed_stderr = stderr.trim();
+
+                if trimmed_stderr.is_empty() {
+                    write!(f, "Error formatting codeblock")
+                } else {
+                    write!(f, "Error formatting codeblock\n{trimmed_stderr}")
+                }
+            }
             Self::MissingBinary(binary_name) => write!(f, "{binary_name} was not found in path"),
             Self::CheckModeChanges(file_count) => {
                 let file_or_files = if file_count == &1 { "file" } else { "files" };


### PR DESCRIPTION
Adds a line of `-` before and after stderr when running using `--debug`. 

![Screenshot from 2024-06-25 14-03-25](https://github.com/hougesen/mdsf/assets/56034786/34a8fd0b-7538-46c2-a60c-b7632e9d215f)
