### PR TITLE
test: decrease go install priority

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,7 +139,7 @@ jobs:
       - name: terraform
         run: ( ( which terraform ) || ( ( which brew && brew tap hashicorp/tap && brew install hashicorp/tap/terraform ) ) || ( echo "Unable to install tool" ) )
       - name: actionlint
-        run: ( ( which actionlint ) || ( ( which go && go install github.com/rhysd/actionlint/cmd/actionlint@latest ) || ( which brew &&  brew install actionlint ) ) || ( echo "Unable to install tool" ) )
+        run: ( ( which actionlint ) || ( ( which brew &&  brew install actionlint ) || ( which go && go install github.com/rhysd/actionlint/cmd/actionlint@latest ) ) || ( echo "Unable to install tool" ) )
       - name: ocamlformat
         run: ( ( which ocamlformat ) || ( ( which opam && eval $(opam env) && opam install ocamlformat ) ) || ( echo "Unable to install tool" ) )
       - name: clang-format

--- a/codegen/src/actions/packages.rs
+++ b/codegen/src/actions/packages.rs
@@ -101,10 +101,6 @@ pub fn generate_install_steps(tools: &Vec<Tool>) -> Vec<WorkflowJobsStep> {
             install_options.push(generate_npm(npm));
         }
 
-        if let Some(go) = &tool.packages.go {
-            install_options.push(generate_go(go));
-        }
-
         if let Some(cargo) = &tool.packages.cargo {
             install_options.push(generate_cargo(cargo));
         }
@@ -115,6 +111,10 @@ pub fn generate_install_steps(tools: &Vec<Tool>) -> Vec<WorkflowJobsStep> {
 
         if let Some(apt) = &tool.packages.apt {
             install_options.push(generate_apt(apt));
+        }
+
+        if let Some(go) = &tool.packages.go {
+            install_options.push(generate_go(go));
         }
 
         if let Some(gem) = &tool.packages.gem {


### PR DESCRIPTION
I have changed the order of test install steps since Go compiles the package from scratch