### PR TITLE
refactor(parser): ignore codeblock modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. Dates are d
 
 #### [Unreleased](https://github.com/hougesen/mdsf/compare/v0.8.3...HEAD)
 
+- refactor(parser): ignore codeblock modifiers [`#892`](https://github.com/hougesen/mdsf/pull/892)
 - docs: add section about caching [`#891`](https://github.com/hougesen/mdsf/pull/891)
 - test(tools): validate uiua:fmt [`#890`](https://github.com/hougesen/mdsf/pull/890)
 - test(tools): validate unimport [`#889`](https://github.com/hougesen/mdsf/pull/889)


### PR DESCRIPTION
The parser will now ignore any extra modifiers added to a codeblock.

````markdown
```javascript no-color
let x = 10;
```
````

Before this patch the "language" extracted from the codeblock above would be `javascript no-color`.

It will now only be `javascript`.
