### PR TITLE
fix(cargo-dist): manually set gh action runs-on to ubuntu-latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ on:
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do
   plan:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
       tag: ${{ !github.event.pull_request && github.ref_name || '' }}
@@ -168,7 +168,7 @@ jobs:
     needs:
       - plan
       - build-local-artifacts
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
@@ -218,7 +218,7 @@ jobs:
     if: ${{ always() && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
@@ -278,7 +278,7 @@ jobs:
     needs:
       - plan
       - host
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PLAN: ${{ needs.plan.outputs.val }}
@@ -323,7 +323,7 @@ jobs:
     needs:
       - plan
       - host
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PLAN: ${{ needs.plan.outputs.val }}
@@ -357,7 +357,7 @@ jobs:
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
     if: ${{ always() && needs.host.result == 'success' && (needs.publish-homebrew-formula.result == 'skipped' || needs.publish-homebrew-formula.result == 'success') && (needs.publish-npm.result == 'skipped' || needs.publish-npm.result == 'success') }}
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. Dates are d
 
 #### [Unreleased](https://github.com/hougesen/mdsf/compare/v0.9.1...HEAD)
 
+- chore: update version to dev [`aa8aa43`](https://github.com/hougesen/mdsf/commit/aa8aa4338208017675170de9ec614c2329fec35c)
+
 #### [v0.9.1](https://github.com/hougesen/mdsf/compare/v0.9.0...v0.9.1)
 
 > 13 April 2025

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -25,3 +25,11 @@ publish-jobs = ["homebrew", "npm"]
 install-updater = false
 # The npm package should have this name
 npm-package = "mdsf-cli"
+
+# https://github.com/axodotdev/cargo-dist/issues/1760
+[dist.github-custom-runners]
+global = "ubuntu-latest"
+
+# https://github.com/axodotdev/cargo-dist/issues/1760
+[dist.github-custom-runners.x86_64-unknown-linux-gnu]
+runner = "ubuntu-latest"


### PR DESCRIPTION
The `ubuntu-20.04` action image was removed yesterday which makes this a high priority.

`cargo-dist`, the release build system used by mdsf, has sadly lost funding (?) which has resulted in project development being paused (?) and no official fix being provided (yet?). 

The changes in `dist-workspace.toml` should be rolled back once https://github.com/axodotdev/cargo-dist/issues/1760 is fixed, or a suitable fork is found.

[astral-sh/cargo-dist](https://github.com/astral-sh/cargo-dist/) seems like it could be a good alternative, but we have yet to see if Astral is interested in actually support a community around the fork.
