### PR TITLE
test(tools): enable tombi tests again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. Dates are d
 
 #### [Unreleased](https://github.com/hougesen/mdsf/compare/v0.9.5...HEAD)
 
+- build(deps): bump which to v8.0.0 [`#1088`](https://github.com/hougesen/mdsf/pull/1088)
 - ci: setup pnpm for testing [`#1087`](https://github.com/hougesen/mdsf/pull/1087)
 - feat(tools): add support for luau-analyze [`#1086`](https://github.com/hougesen/mdsf/pull/1086)
 - feat(tools): add support for the official swift cli [`#1085`](https://github.com/hougesen/mdsf/pull/1085)

--- a/mdsf/tests/tooling.rs
+++ b/mdsf/tests/tooling.rs
@@ -4581,7 +4581,6 @@ mod test_tofu_fmt {
 
 #[cfg(test)]
 mod test_tombi_format {
-    #[ignore]
     #[test_with::executable(tombi || pipx || uv)]
     fn test_tombi_format_toml_fa35f0f5766ac557() -> Result<(), Box<dyn core::error::Error>> {
         let input = r#"[project ]
@@ -4599,7 +4598,6 @@ name = "hello"
 
 #[cfg(test)]
 mod test_tombi_lint {
-    #[ignore]
     #[test_with::executable(tombi || pipx || uv)]
     fn test_tombi_lint_toml_249ef29da68d9e6d() -> Result<(), Box<dyn core::error::Error>> {
         let input = r#"[project]

--- a/tools/tombi/plugin.json
+++ b/tools/tombi/plugin.json
@@ -7,7 +7,6 @@
       "arguments": ["format", "$PATH"],
       "tests": [
         {
-          "disabled": true,
           "language": "toml",
           "test_input": "[project ]\nname =     \"hello\"",
           "test_output": "[project]\nname = \"hello\"\n"
@@ -18,7 +17,6 @@
       "arguments": ["lint", "$PATH"],
       "tests": [
         {
-          "disabled": true,
           "language": "toml",
           "test_input": "[project]\nname = \"hello\"\n",
           "test_output": "[project]\nname = \"hello\"\n"


### PR DESCRIPTION
Tests were disabled because of an issue with schemastore