### PR TITLE
refactor(tombi): use stdin when formatting using tombi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. Dates are d
 
 #### [Unreleased](https://github.com/hougesen/mdsf/compare/v0.9.6...HEAD)
 
+- chore(dependabot): revert back to individual declarations [`#1135`](https://github.com/hougesen/mdsf/pull/1135)
 - build(deps): update schemars to v1.0.1 [`#1134`](https://github.com/hougesen/mdsf/pull/1134)
 - build(deps): bump owo-colors from 4.2.1 to 4.2.2 [`#1133`](https://github.com/hougesen/mdsf/pull/1133)
 - feat(tools): add support for keep-sorted [`#1132`](https://github.com/hougesen/mdsf/pull/1132)

--- a/README.md
+++ b/README.md
@@ -1100,7 +1100,7 @@ That can be changed by specifying the `newline` config option.
 | `textlint`                   | `textlint $PATH`                                                                        |
 | `tlint:format`               | `tlint format $PATH`                                                                    |
 | `tofu:fmt`                   | `tofu fmt -write=true $PATH`                                                            |
-| `tombi:format`               | `tombi format $PATH`                                                                    |
+| `tombi:format`               | `tombi format -`                                                                        |
 | `tombi:lint`                 | `tombi lint $PATH`                                                                      |
 | `toml-sort`                  | `toml-sort -i $PATH`                                                                    |
 | `topiary`                    | `topiary format $PATH`                                                                  |

--- a/mdsf/src/tools/mod.rs
+++ b/mdsf/src/tools/mod.rs
@@ -2852,7 +2852,7 @@ pub enum Tooling {
     ///
     /// [https://github.com/tombi-toml/tombi](https://github.com/tombi-toml/tombi)
     ///
-    /// `tombi format $PATH`
+    /// `tombi format -`
     TombiFormat,
 
     #[serde(rename = "tombi:lint")]

--- a/mdsf/src/tools/tombi_format.rs
+++ b/mdsf/src/tools/tombi_format.rs
@@ -7,10 +7,10 @@ use crate::runners::CommandType;
 #[inline]
 pub fn set_args(
     mut cmd: std::process::Command,
-    file_path: &std::path::Path,
+    _file_path: &std::path::Path,
 ) -> std::process::Command {
     cmd.arg("format");
-    cmd.arg(file_path);
+    cmd.arg("-");
     cmd
 }
 
@@ -20,4 +20,4 @@ pub const COMMANDS: [CommandType; 3] = [
     CommandType::Pipx("tombi"),
 ];
 
-pub const IS_STDIN: bool = false;
+pub const IS_STDIN: bool = true;

--- a/schemas/development/mdsf.schema.json
+++ b/schemas/development/mdsf.schema.json
@@ -1723,7 +1723,7 @@
           "const": "tofu:fmt"
         },
         {
-          "description": "TOML Formatter / Linter\n\n[https://github.com/tombi-toml/tombi](https://github.com/tombi-toml/tombi)\n\n`tombi format $PATH`",
+          "description": "TOML Formatter / Linter\n\n[https://github.com/tombi-toml/tombi](https://github.com/tombi-toml/tombi)\n\n`tombi format -`",
           "type": "string",
           "const": "tombi:format"
         },

--- a/schemas/v0.9.7-next/mdsf.schema.json
+++ b/schemas/v0.9.7-next/mdsf.schema.json
@@ -1723,7 +1723,7 @@
           "const": "tofu:fmt"
         },
         {
-          "description": "TOML Formatter / Linter\n\n[https://github.com/tombi-toml/tombi](https://github.com/tombi-toml/tombi)\n\n`tombi format $PATH`",
+          "description": "TOML Formatter / Linter\n\n[https://github.com/tombi-toml/tombi](https://github.com/tombi-toml/tombi)\n\n`tombi format -`",
           "type": "string",
           "const": "tombi:format"
         },

--- a/tools/tombi/plugin.json
+++ b/tools/tombi/plugin.json
@@ -4,7 +4,8 @@
   "categories": ["formatter", "linter"],
   "commands": {
     "format": {
-      "arguments": ["format", "$PATH"],
+      "arguments": ["format", "-"],
+      "stdin": true,
       "tests": [
         {
           "language": "toml",


### PR DESCRIPTION
Tombi recently made a change that resulted in files in /tmp/ being ignored. This should fix it. 