### PR TITLE
fix(mdsf-vscode): fix mdsf-vscode error log

### DIFF
--- a/mdsf-vscode/src/extension.ts
+++ b/mdsf-vscode/src/extension.ts
@@ -79,7 +79,7 @@ async function formatFile(filePath: string, cwd?: string | URL | undefined) {
       output += data.toString();
     });
 
-    p.on("err", (err) => {
+    p.on("error", (err) => {
       console.error("format error", err);
 
       reject("Failed to start mdsf");


### PR DESCRIPTION
Rename 'err' event to 'error' in extension.ts.

Result: 

<img width="1626" height="992" alt="image" src="https://github.com/user-attachments/assets/990d38ce-8c6a-4b0f-8ff0-81eea3181000" />

Closes #1270