### PR TITLE
build: remove custom runners from cargo-dist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ on:
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do
   plan:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-22.04"
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
       tag: ${{ !github.event.pull_request && github.ref_name || '' }}
@@ -170,7 +170,7 @@ jobs:
     needs:
       - plan
       - build-local-artifacts
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-22.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
@@ -221,7 +221,7 @@ jobs:
     if: ${{ always() && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-22.04"
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
@@ -282,7 +282,7 @@ jobs:
     needs:
       - plan
       - host
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-22.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PLAN: ${{ needs.plan.outputs.val }}
@@ -328,7 +328,7 @@ jobs:
     needs:
       - plan
       - host
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-22.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PLAN: ${{ needs.plan.outputs.val }}
@@ -362,7 +362,7 @@ jobs:
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
     if: ${{ always() && needs.host.result == 'success' && (needs.publish-homebrew-formula.result == 'skipped' || needs.publish-homebrew-formula.result == 'success') && (needs.publish-npm.result == 'skipped' || needs.publish-npm.result == 'success') }}
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-22.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. Dates are d
 
 #### [Unreleased](https://github.com/hougesen/mdsf/compare/v0.10.7...HEAD)
 
+- ci: bump lua action versions [`#1334`](https://github.com/hougesen/mdsf/pull/1334)
 - build(deps): bump clap from 4.5.47 to 4.5.48 [`#1304`](https://github.com/hougesen/mdsf/pull/1304)
 - build(deps): bump tempfile from 3.22.0 to 3.23.0 [`#1313`](https://github.com/hougesen/mdsf/pull/1313)
 - build(deps): bump clap_complete from 4.5.57 to 4.5.58 [`#1302`](https://github.com/hougesen/mdsf/pull/1302)

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -25,15 +25,3 @@ publish-jobs = ["homebrew", "npm"]
 install-updater = false
 # The npm package should have this name
 npm-package = "mdsf-cli"
-
-# https://github.com/axodotdev/cargo-dist/issues/1760
-[dist.github-custom-runners]
-global = "ubuntu-latest"
-
-# https://github.com/actions/runner-images/issues/12045
-[dist.github-custom-runners.x86_64-pc-windows-msvc]
-runner = "windows-latest"
-
-# https://github.com/axodotdev/cargo-dist/issues/1760
-[dist.github-custom-runners.x86_64-unknown-linux-gnu]
-runner = "ubuntu-latest"


### PR DESCRIPTION
Use the default runner used by cargo-dist for each build.

Closes #1322 
